### PR TITLE
CASMCMS-6966: specify additional inventory override in configuration

### DIFF
--- a/src/cray/cfs/operator/events/session_events.py
+++ b/src/cray/cfs/operator/events/session_events.py
@@ -499,8 +499,8 @@ class CFSSessionController:
         """
         options.update()
         if 'configuration' in session_data:
-            cfs_config = get_configuration(configuration_name)
             configuration_name = session_data['configuration']['name']
+            cfs_config = get_configuration(configuration_name)
             configuration = cfs_config.get('layers', [])
             configuration_limit = session_data['configuration'].get('limit', '')
             additional_inventory = cfs_config.get('additional_inventory', {})


### PR DESCRIPTION
in the case of multiple developers it is frequently the case that the
inventory may be mutating along with the code.  therefore it is useful
to be able to specify the specific source of the inventory (commitid) as
part of the configuration.  this change reads an "additional_inventory"
dictionary from the configuration json document.  if it is populated
correctly with cloneUrl and commit (just like the layers), that
information is used.  This additional inventory specified in the
configuration specification overrides the additionalInventoryURL CFS
option if it is present.