### PR TITLE
Support --buid-arg for upstream repos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,13 @@
 # Copyright 2019-2020 Hewlett Packard Enterprise Development LP
-FROM dtr.dev.cray.com/baseos/alpine:3.12.0 as base
+ARG BASE_CONTAINER=dtr.dev.cray.com/baseos/alpine:3.12.0
+FROM  ${BASE_CONTAINER} as base
+ARG PIP_INDEX_URL=https://arti.dev.cray.com:443/artifactory/api/pypi/pypi-remote/simple
+
+
 WORKDIR /app
 RUN apk add --no-cache gcc musl-dev openssh libffi-dev openssl-dev python3-dev py3-pip make curl bash
 ADD constraints.txt requirements.txt /app/
-RUN PIP_INDEX_URL=https://arti.dev.cray.com:443/artifactory/api/pypi/pypi-remote/simple \
+RUN PIP_INDEX_URL=${PIP_INDEX_URL} \
     pip3 install --no-cache-dir -U pip && \
     pip3 install --no-cache-dir -U wheel && \
     pip3 install --no-cache-dir -r requirements.txt
@@ -13,8 +17,9 @@ RUN cd /app/lib && pip3 install --no-cache-dir .
 
 # Nox Environment
 FROM base as nox
+ARG PIP_INDEX_URL=https://arti.dev.cray.com:443/artifactory/api/pypi/pypi-remote/simple
 COPY requirements-dev.txt noxfile.py /app/
-RUN PIP_INDEX_URL=https://arti.dev.cray.com:443/artifactory/api/pypi/pypi-remote/simple \
+RUN PIP_INDEX_URL=${PIP_INDEX_URL} \
     pip3 install --ignore-installed distlib --no-cache-dir -r /app/requirements-dev.txt
 
 # Unit testing


### PR DESCRIPTION
This PR alone will not fully address issue #2.  More work is needed to make the liveness python library available externally and to then deprecate the --index-url flags from the requirements.txt files.  It's a start though.  Use build args like:

docker build -t cfs-operator-test --build-arg BASE_CONTAINER=alpine:3.12.0 --build-arg PIP_INDEX_URL=https://pypi.python.org/simple/ -f Dockerfile .

Keep in mind that in Dockerfiles the ARGS are cleared at each FROM line which is why they are defined multiple times in the same file.