### PR TITLE
CASMTRIAGE-1858: Fix exit code on successful inventory creation (1.0)

### DIFF
--- a/src/cray/cfs/inventory/__main__.py
+++ b/src/cray/cfs/inventory/__main__.py
@@ -92,6 +92,7 @@ def main():
     except Exception as err:
         LOGGER.error("An unknown exception occurred: {}".format(err))
         raise
+    return 0
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Summary and Scope

Fixes the exit code for inventory creation when there are no errors.  The exit code is written to a file used by other containers in a CFS job, and without this "None" was being returned and written to the file.

### Issues and Related PRs

* Resolves CASMTRIAGE-1858

### Testing

Tested on:

* locally

minimal changes, ran and checked the exit code/file

### Risks and Mitigations

None