### PR TITLE
CASMTRIAGE-1880: Improve reporting for components not in CFS (1.1)

### DIFF
--- a/src/cray/cfs/operator/events/session_events.py
+++ b/src/cray/cfs/operator/events/session_events.py
@@ -494,6 +494,10 @@ class CFSSessionController:
                     client.V1EnvVar(
                         name='ANSIBLE_ROLES_PATH',
                         value=roles_path
+                    ),
+                    client.V1EnvVar(
+                        name='INVENTORY_TYPE',
+                        value=session_data['target']['definition']
                     )
                 ],  # env
                 volume_mounts=[


### PR DESCRIPTION
### Summary and Scope

Removes status reporting for image customization (in conjunction with an AEE change), and adds additional output to clarify warnings when they do occur.

### Issues and Related PRs

* Resolves CASMTRIAGE-1880

### Testing

Tested on:

* Drax

Deployed and tested image customization to confirm that no errors were reported in the Ansible logs.

### Risks and Mitigations

None