### PR TITLE
CASMCMS-7428: Update to use non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,4 +59,5 @@ CMD ["nox", "--nocolor", "-s", "lint"]
 # Main application - CFS Kubernetes Operator
 FROM base as application
 RUN mkdir -p /inventory
+USER nobody:nobody
 ENTRYPOINT [ "python3", "-m", "cray.cfs.operator" ]

--- a/kubernetes/cray-cfs-operator/requirements.yaml
+++ b/kubernetes/cray-cfs-operator/requirements.yaml
@@ -1,5 +1,5 @@
 ---
 dependencies:
   - name: cray-service
-    version: "^2.0.0"
-    repository: "@cray-internal"
+    version: "^4.0.0"
+    repository: "@cray-algol60"

--- a/src/cray/cfs/operator/liveness/__init__.py
+++ b/src/cray/cfs/operator/liveness/__init__.py
@@ -21,7 +21,7 @@
 # (MIT License)
 import os
 
-WORKING_DIRECTORY = '/var/'
+WORKING_DIRECTORY = '/tmp/'
 TIMESTAMP_PATH = os.path.join(WORKING_DIRECTORY, 'timestamp')
 
 os.makedirs(WORKING_DIRECTORY, exist_ok=True)


### PR DESCRIPTION
### Summary and Scope

Updates the docker image to use a non-root user, and updates the base chart to use the new non-root security context

### Issues and Related PRs

* Resolves CASMCMS-7428

### Testing

Tested on:

* Wasp

Upgraded chart, tested session operations, and confirmed pod security context

### Risks and Mitigations

None