### PR TITLE
CASMCMS-6914: Add configuration label to cfs jobs

### DIFF
--- a/src/cray/cfs/operator/events/session_events.py
+++ b/src/cray/cfs/operator/events/session_events.py
@@ -618,6 +618,7 @@ class CFSSessionController:
                             'cfsversion': 'v2',
                             'app.kubernetes.io/name': 'cray-cfs-aee',
                             'aee': session_data['name'],
+                            'configuration': session_data.get('configuration', {}).get('name', '')
                         },
                     ),  # V1ObjectMeta
                     spec=client.V1PodSpec(


### PR DESCRIPTION
### Summary and Scope

This adds a label to the cfs session job/pod to allow users to search the pods by the configuration that was applied.

### Issues and Related PRs

* Resolves CASMCMS-6914

### Testing

Tested on:

* Mug

Updated the operator and started a new session, checking the pod labels.

### Risks and Mitigations

None