### PR TITLE
CASMCMS-7645: Making minor README change just to build with the new cray-aee version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cray Configuration Framework Service Operator
 
-A Kubernetes for managing Ansible Execution Environments through the
+A Kubernetes deployment for managing Ansible Execution Environments through the
 [Cray Configuration Framework Service](https://github.com/Cray-HPE/config-framework-service).
 A Config Framework Sessions manages the setup, launch, and teardown of
 [Ansible Execution Environments](https://github.com/Cray-HPE/ansible-execution-environment)


### PR DESCRIPTION
This PR has no real content change. It is just so that we can build a new cfs-operator version to pull in the new cray-aee (with the fix for CASMCMS-7645). 