### PR TITLE
CASMCMS-7648: Fix handling of newlines during git clone

### DIFF
--- a/src/cray/cfs/operator/events/session_events.py
+++ b/src/cray/cfs/operator/events/session_events.py
@@ -331,7 +331,10 @@ class CFSSessionController:
             split_url = clone_url.split('/')
             git_credentials_helper = 'git config --global credential.helper store'
             git_credentials_setup = 'echo "{}" > ~/.git-credentials'.format(
-                ''.join([split_url[0], '//${VCS_USER}:${VCS_PASSWORD}@', split_url[2]])
+                ''.join([
+                    split_url[0],
+                    '//${VCS_USER//[$\'\t\r\n\']}:${VCS_PASSWORD//[$\'\t\r\n\']}@',
+                    split_url[2]])
             )
 
             git_command = 'RETRIES={retries}; '\


### PR DESCRIPTION
### Summary and Scope

Fixes a case where a newline in the username or password creates an invalid .git-credentials file

### Issues and Related PRs

* Resolves CASMCMS-7648

### Testing

Tested on:

* Thanos

Manually tested that the modification to the command produced the correct file contents.

### Risks and Mitigations

None