### PR TITLE
Added ClusterRole and ClusterRoleBinding for NCN lifecycle coordination

### DIFF
--- a/kubernetes/cray-cfs-operator/templates/clusterrole.yaml
+++ b/kubernetes/cray-cfs-operator/templates/clusterrole.yaml
@@ -1,0 +1,50 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cray-cfs
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - delete
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+- apiGroups:
+  - "policy"
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - "apps"
+  resources:
+  - daemonsets
+  verbs:
+  - get
+  - list
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - pods/eviction
+  verbs:
+  - create

--- a/kubernetes/cray-cfs-operator/templates/clusterrolebinding.yaml
+++ b/kubernetes/cray-cfs-operator/templates/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cray-cfs
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cray-cfs
+subjects:
+- kind: ServiceAccount
+  name: cray-cfs
+  namespace: services


### PR DESCRIPTION
## Summary and Scope

This mod adds a ClusterRole and ClusterRoleBinding to enable the CFS service account access to all of the resources cluster wide (because activities like draining a node are cluster wide).

This change should be fully backwards compatible. 

## Issues and Related PRs

CASMINST-3572

## Testing

Tested on Mug, verified that with two files applied a full end-to-end rebuild worked as expected.

### Tested on:

Mug

### Test description:

Applied files, ran CFS session, verified results.

## Risks and Mitigations

No known risk.

## Pull Request Checklist

- [x ] Version number(s) incremented, if applicable
- [x ] Copyrights updated
- [x ] License file intact
- [x ] Target branch correct
- [x ] CHANGELOG.md updated
- [x ] Testing is appropriate and complete, if applicable
- [x ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable
