### PR TITLE
CASMCMS-7614: Fix versioning for the aee image annotation

### DIFF
--- a/update_versions.conf
+++ b/update_versions.conf
@@ -35,3 +35,4 @@ targetfile: kubernetes/cray-cfs-operator/Chart.yaml
 sourcefile: cray-aee.version
 tag: 0.0.0-aee
 targetfile: kubernetes/cray-cfs-operator/values.yaml
+targetfile: kubernetes/cray-cfs-operator/Chart.yaml


### PR DESCRIPTION
## Summary and Scope

Fixes the annotation for the aee image by adding the file to the update_version.conf

## Issues and Related PRs

* Resolves CASMCMS-7614

## Testing

NA - build only

## Risks and Mitigations

None


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

