### PR TITLE
CASMCMS-7725: Update alpine/git image to fix CVE

### DIFF
--- a/kubernetes/cray-cfs-operator/Chart.yaml
+++ b/kubernetes/cray-cfs-operator/Chart.yaml
@@ -26,5 +26,5 @@ annotations:
     - name: cray-aee
       image: artifactory.algol60.net/csm-docker/stable/cray-aee:0.0.0-aee
     - name: alpine/git
-      image: artifactory.algol60.net/csm-docker/stable/docker.io/alpine/git:1.0.15
+      image: alpine/git:v2.32.0
   artifacthub.io/license: MIT

--- a/kubernetes/cray-cfs-operator/values.yaml
+++ b/kubernetes/cray-cfs-operator/values.yaml
@@ -8,8 +8,8 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 util_image:
-  repository: artifactory.algol60.net/csm-docker/stable/docker.io/alpine/git
-  version: 1.0.15
+  repository: alpine/git
+  version: v2.32.0
 ims_image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-cfs-operator
 aee_image:


### PR DESCRIPTION
## Summary and Scope

Updates the alpine/git image used to clone in CFS jobs.

## Issues and Related PRs

* Resolves CASMCMS-7725

## Testing

### Tested on:

  * Mug
  
### Test description:

Updated the configmap and ran a session with the new image successfully.

## Risks and Mitigations

None

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [S] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

