### PR TITLE
CASMTRIAGE-2909: Update teardown to use non-root key source

### DIFF
--- a/src/cray/cfs/teardown/__main__.py
+++ b/src/cray/cfs/teardown/__main__.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# Copyright 2019-2021 Hewlett Packard Enterprise Development LP
+# Copyright 2019-2022 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -129,7 +129,7 @@ def _finish_the_job(job_id: str, cfs_name: str) -> None:
         if ssh_container['name'] == cfs_name:
             ssh_host = ssh_container['connection_info']['cluster.local']['host']
             ssh_port = ssh_container['connection_info']['cluster.local']['port']
-            key = paramiko.ecdsakey.ECDSAKey.from_private_key_file('/root/.ssh/id_image')
+            key = paramiko.ecdsakey.ECDSAKey.from_private_key_file('/inventory/ssh/id_image')
             pclient = paramiko.SSHClient()
             for x in range(20):
                 try:
@@ -283,7 +283,7 @@ def main() -> None:  # noqa: C901
 
     version = get_distribution('cray-cfs').version
     LOGGER.info('Starting CFS IMS Teardown version=%s, namespace=%s', version, cfs_namespace)
-    LOGGER.info("Waiting for `ansible` container to finish.")
+    LOGGER.info("Waiting for `ansible` containers to finish.")
     if 'LAYER_PREVIOUS' in os.environ:
         v2 = True
         ansible_status = wait_for_aee_finish_v2(os.environ['LAYER_PREVIOUS'])


### PR DESCRIPTION
## Summary and Scope

This removes the code that copies the ssh keys to /root, since that is no longer possible since these containers no longer run as root.  The one place these ssh keys actually matter is during teardown, so that code has been updated to point at the new source of the keys.

The keys are also still used in the Ansible containers, but the code to copy them to the appropriate location is in the entrypoint for the aee image, and so Ansible containers are unaffected by this change.

## Issues and Related PRs

* Resolves CASMTRIAGE-2909

## Testing

### Tested on:

  * Hela

### Test description:

The changes were deployed and CFS was successfully run against both live nodes and images.

## Risks and Mitigations

None

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

