### PR TITLE
CASMCMS-7447: Update to use hsm v2

### DIFF
--- a/src/cray/cfs/inventory/dynamic.py
+++ b/src/cray/cfs/inventory/dynamic.py
@@ -122,7 +122,7 @@ class DynamicInventory(CFSInventoryBase):
         return {}
 
     def _get_data(self, endpoint):
-        url = 'http://{}/hsm/v1/{}'.format(self.hsm_host, endpoint)
+        url = 'http://{}/hsm/v2/{}'.format(self.hsm_host, endpoint)
         LOGGER.debug('Querying %s for inventory data.', url)
         r = self.session.get(url, verify=self.ca_cert)
         r.raise_for_status()


### PR DESCRIPTION
## Summary and Scope

Switches to using HSM v2 since v1 is going away.  There were no changes in the data, so only the endpoint has changed.

## Issues and Related PRs

* Resolves CASMCMS-7447

## Testing

### Tested on:

  * Hela

### Test description:

Deployed the change and ran a test session.  Also compared the data from all used endpoints to confirm that there were no changes.

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

