### PR TITLE
CASMCMS-8029: Mitigate umask issues associated with copying keys

### DIFF
--- a/src/cray/cfs/operator/events/session_events.py
+++ b/src/cray/cfs/operator/events/session_events.py
@@ -378,6 +378,7 @@ class CFSSessionController:
         # For live nodes, use the signed keys from vault with a cert generated
         # by the CFS trust mechanisms
         create_ssh_keys_cmd = 'cp /secret-keys/* {0}/ssh/ && ' \
+                              'chmod 600 {0}/ssh/id_ecdsa && ' \
                               'cp /secret-certs/* {0}/ssh/ '.format(SHARED_DIRECTORY)
 
         # For image customization, generate some keys for use with Ansible


### PR DESCRIPTION
During CFS startup of an AEE job, the inventory is contructed exactly once. However, the keys may be provided to the running inventory pod using a number of different bit configurations, depending on the umask as set by the product release (or the user on a worker node), or the default policy modes set by k8s. As a result, we need to explicitly set the permision bits on copied files to be more restrictive. This allows Ansible (and the underlying ssh transport) to always work regardless of what form the secrets arrive in during CFS session launch.


