### PR TITLE
CASMCMS-7941: Move KafkaWrapper for events into retry loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
-
 - Convert to gitflow/gitversion.
+- Fixed Kafka retries
 

--- a/src/cray/cfs/operator/events/session_events.py
+++ b/src/cray/cfs/operator/events/session_events.py
@@ -77,11 +77,11 @@ class CFSSessionController:
         threading.Thread(target=self._run).start()
 
     def _run(self):  # pragma: no cover
-        kafka = KafkaWrapper('cfs-session-events',
-                             group_id='cfs-operator',
-                             enable_auto_commit=False)
         while True:
             try:
+                kafka = KafkaWrapper('cfs-session-events',
+                                     group_id='cfs-operator',
+                                     enable_auto_commit=False)
                 for event in kafka.consumer:
                     self._handle_event(event.value, kafka)
             except Exception as e:


### PR DESCRIPTION
## Summary and Scope

Moves the Kafka setup into the retry loop to prevent getting stuck if Kafka is down on startup

## Issues and Related PRs

* Resolves CASMCMS-7941

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

