### PR TITLE
Fixes for using additional inventory with image customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Fixed container users to avoid permissions issues when using additional inventory
+
 ## [1.15.0] - 7/19/22
 ### Changed
 - Updated build references to AEE 1.3.0 (gitversion/giflow conversion).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed container users to avoid permissions issues when using additional inventory
 
+### Changed
+- Changed image customization to allow additional inventory, while adding an automatic limit to Ansible
+
 ## [1.15.0] - 7/19/22
 ### Changed
 - Updated build references to AEE 1.3.0 (gitversion/giflow conversion).

--- a/src/cray/cfs/inventory/image/__init__.py
+++ b/src/cray/cfs/inventory/image/__init__.py
@@ -119,7 +119,7 @@ class ImageRootInventory(CFSInventoryBase):
                     'job_id': job_id,
                     'image_id': image,
                 }
-                inventory[group]['hosts'][image_name] = {
+                inventory[group]['hosts'][image] = {
                     'ansible_host': host,
                     'ansible_port': port,
                     'cray_cfs_image': True,

--- a/src/cray/cfs/operator/events/session_events.py
+++ b/src/cray/cfs/operator/events/session_events.py
@@ -443,6 +443,8 @@ class CFSSessionController:
                 ansible_args.append(ansible_verbosity)
 
             limit = ansible_spec.get('limit', None)
+            if session_data['target']['definition'] == 'image' and not limit:
+                limit = ','.join([member for group in session_data['target']['groups'] for member in group['members']])
             if limit:
                 ansible_args.append('--limit')
                 ansible_args.append(limit)
@@ -585,10 +587,7 @@ class CFSSessionController:
         self._set_volumes(ansible_config)
 
         # Git clone containers
-        if session_data['target']['definition'] == "image":
-            # Disable additional inventory for image customization
-            additional_inventory = None
-        elif options.additional_inventory_url and not additional_inventory:
+        if options.additional_inventory_url and not additional_inventory:
             additional_inventory = {'cloneUrl': options.additional_inventory_url,
                                     'commit': 'master'}
         clone_containers = self._get_clone_containers(configuration, additional_inventory)

--- a/src/cray/cfs/operator/events/session_events.py
+++ b/src/cray/cfs/operator/events/session_events.py
@@ -413,6 +413,9 @@ class CFSSessionController:
                 self._job_env['SSL_CAINFO']
             ],  # env
             command=['/bin/bash', '-c'],
+            security_context = client.V1SecurityContext(
+                run_as_user = 0
+            ),
             args=command,
         )  # V1Container
 
@@ -534,6 +537,9 @@ class CFSSessionController:
                 )
             ],  # env
             command=['/bin/bash', '-c'],
+            security_context = client.V1SecurityContext(
+                run_as_user = 0
+            ),
             args=teardown_args,
         )  # V1Container
 


### PR DESCRIPTION
## Summary and Scope

Fixes two issues reported by NERSC.
* Fixes container users so to avoid permissions issues caused by having some containers run as root and some as nobody.
* Changes the behavior of image customization to allow additional inventory, and instead use an automatic limit so that nothing targets hosts in the additional inventory.  This allows variables set in the additional inventory to be used.

## Issues and Related PRs

* Resolves CASMCMS-8120
* Resolves CASMCMS-8121

## Testing

### Tested on:

  * Fanta

### Test description:

- Tested image customization with and without additional inventory, before and after these changes.

## Risks and Mitigations

No


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

