### PR TITLE
CASMTRIAGE-3835: Escalate pod priority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.16.1] - 8/4/22
+### Fixed
+- Escalated pod priority so that configuration has a better chance of running when a node is cordoned
+
 ## [1.16.0] - 8/4/22
 ### Fixed
 - Fixed container users to avoid permissions issues when using additional inventory

--- a/kubernetes/cray-cfs-operator/values.yaml
+++ b/kubernetes/cray-cfs-operator/values.yaml
@@ -47,6 +47,7 @@ cray-service:
   serviceAccountName: cray-cfs
   labels:
     app: cray-cfs-operator
+  priorityClassName: csm-high-priority-service
   containers:
     cray-cfs-operator:
       name: cray-cfs-operator

--- a/src/cray/cfs/operator/events/session_events.py
+++ b/src/cray/cfs/operator/events/session_events.py
@@ -625,6 +625,7 @@ class CFSSessionController:
                     ),  # V1ObjectMeta
                     spec=client.V1PodSpec(
                         service_account_name=self.env['CRAY_CFS_SERVICE_ACCOUNT'],
+                        priority_class_name= "csm-high-priority-service",
                         restart_policy="Never",
                         volumes=[
                             self._job_volumes['CA_PUBKEY'],


### PR DESCRIPTION
## Summary and Scope

Escalates the pods to a high priority to improve CFS' ability to run when the system is partially down.

## Issues and Related PRs

* Resolves CASMTRIAGE-3835

## Testing

### Tested on:

  * Mug

### Test description:

Deployed the new image chart and tested basic functions

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

