### PR TITLE
Fixes for several small usability tickets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated dynamic inventory to log and drop invalid HSM group names
 - Image teardown now marks failed images correctly
 - Log levels are now controlled by a CFS option
+- Ansible container limits/requests are now configurable
 
 ### Fixed
 - Spelling corrections.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
 ### Changed
+- Updated dynamic inventory to log and drop invalid HSM group names
+
+### Fixed
 - Spelling corrections.
 
 ## [1.16.1] - 8/4/22

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated dynamic inventory to log and drop invalid HSM group names
 - Image teardown now marks failed images correctly
+- Log levels are now controlled by a CFS option
 
 ### Fixed
 - Spelling corrections.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Spelling corrections.
+- Fixed the exit code when git checkout fails
 
 ## [1.16.1] - 8/4/22
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added a new parameter for naming image customization results
+
 ### Changed
 - Updated dynamic inventory to log and drop invalid HSM group names
 - Image teardown now marks failed images correctly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added a new parameter for naming image customization results
 - Added a pointer to IMS logs when image inventory creation fails
+- Added cfs_image host group to image customization inventory
 
 ### Changed
 - Updated dynamic inventory to log and drop invalid HSM group names

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Added a new parameter for naming image customization results
+- Added a pointer to IMS logs when image inventory creation fails
 
 ### Changed
 - Updated dynamic inventory to log and drop invalid HSM group names

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Updated dynamic inventory to log and drop invalid HSM group names
+- Image teardown now marks failed images correctly
 
 ### Fixed
 - Spelling corrections.

--- a/kubernetes/cray-cfs-operator/templates/configmap.yaml
+++ b/kubernetes/cray-cfs-operator/templates/configmap.yaml
@@ -34,6 +34,8 @@ data:
   cray_cfs_util_image: "{{ .Values.util_image.repository }}:{{ .Values.util_image.version }}"
   cray_cfs_aee_image: "{{ .Values.aee_image.repository }}:{{ .Values.aee_image.version }}"
   cray_cfs_ims_image: "{{ .Values.ims_image.repository }}:{{ .Values.ims_image.version | default $baseChartValues.global.appVersion }}"
+  ansible_container_requests: '{"memory": "4Gi", "cpu": "500m"}'
+  ansible_container_limits: '{"memory": "6Gi", "cpu": "8"}'
 
 ---
 apiVersion: v1

--- a/kubernetes/cray-cfs-operator/values.yaml
+++ b/kubernetes/cray-cfs-operator/values.yaml
@@ -68,6 +68,16 @@ cray-service:
           configMapKeyRef:
             name: cray-cfs-operator-config
             key: cray_cfs_aee_image
+      - name: CRAY_CFS_ANSIBLE_CONTAINER_REQUESTS
+        valueFrom:
+          configMapKeyRef:
+            name: cray-cfs-operator-config
+            key: ansible_container_requests
+      - name: CRAY_CFS_ANSIBLE_CONTAINER_LIMITS
+        valueFrom:
+          configMapKeyRef:
+            name: cray-cfs-operator-config
+            key: ansible_container_limits
       - name: CRAY_CFS_CONFIGMAP_PUBLIC_KEY
         value: "cray-configmap-ca-public-key"
       - name: CRAY_CFS_CA_PUBLIC_KEY

--- a/src/cray/cfs/inventory/__main__.py
+++ b/src/cray/cfs/inventory/__main__.py
@@ -36,7 +36,7 @@ from cray.cfs.inventory.image import ImageRootInventory
 from cray.cfs.inventory.spec import ExplicitInventory
 from cray.cfs.inventory.repo import RepositoryInventory
 from cray.cfs.inventory.dynamic import DynamicInventory
-from cray.cfs.logging import setup_logging
+from cray.cfs.logging import setup_logging, update_logging
 import cray.cfs.operator.cfs.sessions as cfs_sessions
 
 LOGGER = logging.getLogger('cray.cfs.inventory')
@@ -99,6 +99,7 @@ def main():
 
 if __name__ == "__main__":
     setup_logging()
+    update_logging(update_options=True)
     exit_code = 0
     try:
         exit_code = main()

--- a/src/cray/cfs/inventory/dynamic.py
+++ b/src/cray/cfs/inventory/dynamic.py
@@ -88,8 +88,8 @@ class DynamicInventory(CFSInventoryBase):
                 group_name = str(group['label'])
                 if not valid_group_name(group_name):
                     LOGGER.warning(
-                        'Encountered an invalid Ansible group name. \
-                         Ignoring HSM group {}'.format(group_name))
+                        'Encountered an invalid Ansible group name. Ignoring HSM group {}'.format(
+                            group_name))
                     continue
                 inventory[group_name] = hosts
             return inventory

--- a/src/cray/cfs/inventory/dynamic.py
+++ b/src/cray/cfs/inventory/dynamic.py
@@ -24,8 +24,10 @@
 """
 cray.cfs.inventory.dynamic - Generate an inventory from HSM data.
 """
+import keyword
 import logging
 import os
+import re
 import requests
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
@@ -39,10 +41,9 @@ LOGGER = logging.getLogger(__name__)
 class DynamicInventory(CFSInventoryBase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        # FIXME TODO CASMCMS-2777
         self.hsm_host = os.getenv('CRAY_SMD_SERVICE_HOST', 'cray-smd')
         self.ca_cert = os.getenv('SSL_CAINFO')
-        LOGGER.debug('API Gateway is: %s', self.hsm_host)
+        LOGGER.debug('HSM host is: %s', self.hsm_host)
         LOGGER.debug('CA Cert location is: %s', self.ca_cert)
         self._init_session()
 
@@ -84,7 +85,13 @@ class DynamicInventory(CFSInventoryBase):
                 members = group['members']['ids']
                 hosts = {}
                 hosts['hosts'] = {str(member): {} for member in members}
-                inventory[str(group['label'])] = hosts
+                group_name = str(group['label'])
+                if not valid_group_name(group_name):
+                    LOGGER.warning(
+                        'Encountered an invalid Ansible group name. \
+                         Ignoring HSM group {}'.format(group_name))
+                    continue
+                inventory[group_name] = hosts
             return inventory
         except Exception as e:
             LOGGER.error('Encountered an unknown exception getting groups data: {}'.format(e))
@@ -98,7 +105,13 @@ class DynamicInventory(CFSInventoryBase):
                 members = group['members']['ids']
                 hosts = {}
                 hosts['hosts'] = {str(member): {} for member in members}
-                inventory[str(group['name'])] = hosts
+                group_name = str(group['name'])
+                if not valid_group_name(group_name):
+                    LOGGER.warning(
+                        'Encountered an invalid Ansible group name. \
+                         Ignoring HSM partition {}'.format(group_name))
+                    continue
+                inventory[group_name] = hosts
             return inventory
         except Exception as e:
             LOGGER.error('Encountered an unknown exception getting partitions data: {}'.format(e))
@@ -127,3 +140,11 @@ class DynamicInventory(CFSInventoryBase):
         r = self.session.get(url, verify=self.ca_cert)
         r.raise_for_status()
         return r.json()
+
+
+def valid_group_name(name):
+    if not bool(re.match("^[a-zA-Z_][a-zA-Z0-9_]+$", name)):
+        return False
+    if keyword.iskeyword(name):
+        return False
+    return True

--- a/src/cray/cfs/inventory/image/__init__.py
+++ b/src/cray/cfs/inventory/image/__init__.py
@@ -62,6 +62,9 @@ _api_client = client.ApiClient()
 k8score = client.CoreV1Api(_api_client)
 
 
+IMAGE_HOST_GROUP = "cfs_image"
+
+
 def get_IMS_API() -> Tuple[str, str, requests.Session]:
     """
     Retrieve the IMS service host and port and a resilient/retry session object,
@@ -109,6 +112,8 @@ class ImageRootInventory(CFSInventoryBase):
         # Create an inventory file with the IMS images, their groups, and
         # connection information, leave a breadcrumb of image to job info too.
         inventory = {}
+        inventory[IMAGE_HOST_GROUP] = {}
+        inventory[IMAGE_HOST_GROUP]['hosts'] = {}
         self.image_to_job = {}
         for group, images in self.get_groups_members().items():
             inventory[group] = {}
@@ -119,11 +124,11 @@ class ImageRootInventory(CFSInventoryBase):
                     'job_id': job_id,
                     'image_id': image,
                 }
-                inventory[group]['hosts'][image] = {
+                inventory[group]['hosts'][image] = {}
+                inventory[IMAGE_HOST_GROUP]['hosts'][image] = {
                     'ansible_host': host,
                     'ansible_port': port,
                     'cray_cfs_image': True,
-                    # yuck, tested on SLE15 only
                     'ansible_python_interpreter': '/usr/bin/env python3',
                     'ansible_ssh_private_key_file': '/etc/ansible/ssh/id_image',
                 }

--- a/src/cray/cfs/inventory/image/__init__.py
+++ b/src/cray/cfs/inventory/image/__init__.py
@@ -239,7 +239,7 @@ class ImageRootInventory(CFSInventoryBase):
         except requests.exceptions.HTTPError as err:
             raise CFSInventoryError(
                 'Unable to create an IMS customization job for IMS image=%r. '
-                'Reason: %s' % (ims_id, err)
+                'Reason: %s. See the IMS logs for more information.' % (ims_id, err)
             )
 
         # Wait for the SSH container to become available, put the resulting SSH

--- a/src/cray/cfs/inventory/image/__init__.py
+++ b/src/cray/cfs/inventory/image/__init__.py
@@ -162,7 +162,7 @@ class ImageRootInventory(CFSInventoryBase):
                 processes.append(
                     Process(
                         target=ImageRootInventory._request_ims_ssh,
-                        args=(mpq, ims_id, self.cfs_name, key_uuid)
+                        args=(mpq, ims_id, self.cfs_name, key_uuid, self.session['target'])
                     )
                 )
 
@@ -196,24 +196,33 @@ class ImageRootInventory(CFSInventoryBase):
             self._remove_public_key(key_uuid)
 
     @staticmethod
-    def _request_ims_ssh(mpq, ims_id: str, cfs_session: str, public_key_id: str) -> None:
+    def _request_ims_ssh(mpq, ims_id: str, cfs_session: str, public_key_id: str,
+                         session_target: dict) -> None:
         """ Kick off IMS customization job and request an SSH jailed container """
         host, port, session = get_IMS_API()
 
-        # Call IMS to get the image name
-        LOGGER.debug("Retrieving IMS image name for id=%s", ims_id)
-        try:
-            resp = session.get("http://{}:{}/images/{}".format(host, port, ims_id))
-            resp.raise_for_status()
-        except requests.exceptions.HTTPError as err:
-            raise CFSInventoryError(
-                'Unable to determine the name of IMS image=%r. Reason: %s' % (ims_id, err)
-            ) from err
+        archive_name = ""
+        image_map = session_target.get("imageMap", [])
+        for mapping in image_map:
+            if mapping.get("sourceId", "") == ims_id:
+                archive_name = mapping.get("resultName")
+                break
+        else:
+            # Call IMS to get the image name
+            LOGGER.debug("Retrieving IMS image name for id=%s", ims_id)
+            try:
+                resp = session.get("http://{}:{}/images/{}".format(host, port, ims_id))
+                resp.raise_for_status()
+            except requests.exceptions.HTTPError as err:
+                raise CFSInventoryError(
+                    'Unable to determine the name of IMS image=%r. Reason: %s' % (ims_id, err)
+                ) from err
+            archive_name = resp.json()['name'] + "_cfs_" + cfs_session
 
         # Call IMS to kick off a customization job
         body = {
             "job_type": "customize",
-            "image_root_archive_name": resp.json()['name'] + "_cfs_" + cfs_session,
+            "image_root_archive_name": archive_name,
             "artifact_id": ims_id,
             "public_key_id": public_key_id,
             "ssh_containers": [

--- a/src/cray/cfs/logging/__init__.py
+++ b/src/cray/cfs/logging/__init__.py
@@ -27,10 +27,13 @@ cray.cfs.logging - helper functions for logging in CFS
 import logging
 import os
 
+from cray.cfs.operator.cfs.options import options
+
+
 LOGGER = logging.getLogger(__name__)
 
 
-def setup_logging(env_key='CFS_OPERATOR_LOG_LEVEL', default_level='INFO') -> None:
+def setup_logging(env_key='STARTING_LOG_LEVEL', default_level='INFO') -> None:
     """
     Setup the log level base on the environment variable in `env_key`. Fall back
     to the `default_level` if the key doesn't exist in the environment or if an
@@ -48,3 +51,23 @@ def setup_logging(env_key='CFS_OPERATOR_LOG_LEVEL', default_level='INFO') -> Non
 
     if bad_log_level:
         LOGGER.warning('Log level %r is not valid. Falling back to INFO', bad_log_level)
+
+
+def _update_log_level(update_options=False) -> None:
+    """ Updates the current logging level base on the value in the options database """
+    try:
+        if update_options:
+            options.update()
+        if not options.logging_level:
+            return
+        new_level = logging.getLevelName(options.logging_level.upper())
+        current_level = LOGGER.getEffectiveLevel()
+        if current_level != new_level:
+            LOGGER.log(current_level, 'Changing logging level from {} to {}'.format(
+                logging.getLevelName(current_level), logging.getLevelName(new_level)))
+            logger = logging.getLogger()
+            logger.setLevel(new_level)
+            LOGGER.log(new_level, 'Logging level changed from {} to {}'.format(
+                logging.getLevelName(current_level), logging.getLevelName(new_level)))
+    except Exception as e:
+        LOGGER.error('Error updating logging level: {}'.format(e))

--- a/src/cray/cfs/logging/__init__.py
+++ b/src/cray/cfs/logging/__init__.py
@@ -53,7 +53,7 @@ def setup_logging(env_key='STARTING_LOG_LEVEL', default_level='INFO') -> None:
         LOGGER.warning('Log level %r is not valid. Falling back to INFO', bad_log_level)
 
 
-def _update_log_level(update_options=False) -> None:
+def update_logging(update_options=False) -> None:
     """ Updates the current logging level base on the value in the options database """
     try:
         if update_options:

--- a/src/cray/cfs/operator/cfs/options.py
+++ b/src/cray/cfs/operator/cfs/options.py
@@ -34,7 +34,8 @@ ENDPOINT = "%s/%s" % (BASE_ENDPOINT, __name__.lower().split('.')[-1])
 
 DEFAULTS = {
     'sessionTTL': '7d',
-    'additionalInventoryUrl': ''
+    'additionalInventoryUrl': '',
+    'loggingLevel': 'INFO'
 }
 
 
@@ -105,6 +106,10 @@ class Options:
     @property
     def additional_inventory_url(self):
         return self.get_option('additionalInventoryUrl', str)
+
+    @property
+    def logging_level(self):
+        return self.get_option('loggingLevel', str)
 
 
 options = Options()

--- a/src/cray/cfs/operator/events/session_events.py
+++ b/src/cray/cfs/operator/events/session_events.py
@@ -469,8 +469,8 @@ class CFSSessionController:
                 name='ansible-' + str(i),
                 image=self.env['CRAY_CFS_AEE_IMAGE'],
                 resources=client.V1ResourceRequirements(
-                    limits={'memory': '6Gi', 'cpu': '8'},
-                    requests={'memory': '4Gi', 'cpu': '500m'}
+                    limits=json.loads(self.env['CRAY_CFS_ANSIBLE_CONTAINER_LIMITS']),
+                    requests=json.loads(self.env['CRAY_CFS_ANSIBLE_CONTAINER_REQUESTS'])
                 ),
                 env=[
                     self._job_env['SESSION_NAME'],

--- a/src/cray/cfs/operator/events/session_events.py
+++ b/src/cray/cfs/operator/events/session_events.py
@@ -334,7 +334,7 @@ class CFSSessionController:
                           'echo "Cloning successful"; '\
                           'cd {directory}; '\
                           'git checkout {commit}; '\
-                          'exit 0; '\
+                          'exit $?; '\
                           'fi; '\
                           'if [ $COUNT -gt $RETRIES ]; then '\
                           'echo "Cloning exceeded retry limit - Stopping"; '\

--- a/src/cray/cfs/teardown/__main__.py
+++ b/src/cray/cfs/teardown/__main__.py
@@ -123,7 +123,7 @@ def _get_image_to_job() -> Mapping[str, str]:
     return image_to_job
 
 
-def _finish_the_job(job_id: str, cfs_name: str) -> None:
+def _finish_the_job(job_id: str, cfs_name: str, completion_flag: str = "complete") -> None:
     """
     Tell IMS to finish the job by touching the /tmp/complete file in the jail.
 
@@ -155,13 +155,13 @@ def _finish_the_job(job_id: str, cfs_name: str) -> None:
             for x in range(20):
                 try:
                     pclient.set_missing_host_key_policy(paramiko.WarningPolicy())
-                    LOGGER.info("Remotely touching complete file for %s:%s", ssh_host,
+                    LOGGER.info("Remotely touching %s file for %s:%s", completion_flag, ssh_host,
                                 str(ssh_port))
                     pclient.connect(
                         ssh_host, port=ssh_port, pkey=key, username='root',
                         password='',
                     )
-                    pclient.exec_command('touch /tmp/complete')
+                    pclient.exec_command('touch /tmp/{}'.format(completion_flag))
                     break
                 except Exception as e:
                     LOGGER.error(e)
@@ -186,7 +186,7 @@ def do_failed(image_id: str, job_id: str, cfs_name: str, queue) -> None:
         None
     """
     try:
-        _finish_the_job(job_id, cfs_name)
+        _finish_the_job(job_id, cfs_name, completion_flag="failed")
     except Exception as err:
         queue.put(
             ('error', image_id, job_id, err)

--- a/src/cray/cfs/teardown/__main__.py
+++ b/src/cray/cfs/teardown/__main__.py
@@ -70,7 +70,7 @@ import requests
 import yaml
 
 from cray.cfs.inventory.image import get_IMS_API
-from cray.cfs.logging import setup_logging
+from cray.cfs.logging import setup_logging, update_logging
 import cray.cfs.operator.cfs.sessions as cfs_sessions
 from cray.cfs.utils import wait_for_aee_finish_v1, wait_for_aee_finish_v2
 
@@ -445,4 +445,5 @@ def main() -> None:  # noqa: C901
 
 if __name__ == '__main__':
     setup_logging()
+    update_logging(update_options=True)
     main()


### PR DESCRIPTION
## Summary and Scope

Contains changes for 

* CASMCMS-7719: Check HSM group names to make sure they are valid Ansible
* CASMCMS-5919: Fix image teardown to mark failed images
* CASMCMS-7820: Add new parameter for naming image customization results
* CASMCMS-7886: Fix exit code when git checkout fails
* CASMCMS-7639: Add pointer to IMS logs when image inventory creation fails
* CASMCMS-8211: Updated the logging level to be controlled by CFS options
* CASMCMS-8208: Make Ansible container limits/requests configurable
* CASMCMS-8243: Add cfs_image host group to image inventory

## Testing

### Tested on:

  * Tested on starlord

### Test description:

Generally ran sessions and verified output, changing options and other parameters as needed to test the individual tickets

## Risks and Mitigations

None

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

