### PR TITLE
CASMCMS-8243: Add an image host group to image inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added cfs_image host group to image customization inventory
 
 ### Changed
 - Spelling corrections.

--- a/src/cray/cfs/inventory/image/__init__.py
+++ b/src/cray/cfs/inventory/image/__init__.py
@@ -62,6 +62,9 @@ _api_client = client.ApiClient()
 k8score = client.CoreV1Api(_api_client)
 
 
+IMAGE_HOST_GROUP = "cfs_image"
+
+
 def get_IMS_API() -> Tuple[str, str, requests.Session]:
     """
     Retrieve the IMS service host and port and a resilient/retry session object,
@@ -109,6 +112,8 @@ class ImageRootInventory(CFSInventoryBase):
         # Create an inventory file with the IMS images, their groups, and
         # connection information, leave a breadcrumb of image to job info too.
         inventory = {}
+        inventory[IMAGE_HOST_GROUP] = {}
+        inventory[IMAGE_HOST_GROUP]['hosts'] = {}
         self.image_to_job = {}
         for group, images in self.get_groups_members().items():
             inventory[group] = {}
@@ -119,11 +124,11 @@ class ImageRootInventory(CFSInventoryBase):
                     'job_id': job_id,
                     'image_id': image,
                 }
-                inventory[group]['hosts'][image] = {
+                inventory[group]['hosts'][image] = {}
+                inventory[IMAGE_HOST_GROUP]['hosts'][image] = {
                     'ansible_host': host,
                     'ansible_port': port,
                     'cray_cfs_image': True,
-                    # yuck, tested on SLE15 only
                     'ansible_python_interpreter': '/usr/bin/env python3',
                     'ansible_ssh_private_key_file': '/etc/ansible/ssh/id_image',
                 }


### PR DESCRIPTION
## Summary and Scope

Sets up a new "cfs_image" group in image customization inventory for use targeting Ansible plays.

## Issues and Related PRs

* Resolves CASMCMS-8243
* Related to CASMCMS-8236

## Testing

### Tested on:

  * Starlord

### Test description:

Ran both customization and personalization sessions with playbooks that targeted Compute, cfs_image, Compute:&cfs_image, and Compute:!cfs_image

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

