### PR TITLE
CASMTRIAGE-4452: Remove high priority from cfs session pods

### DIFF
--- a/src/cray/cfs/operator/events/session_events.py
+++ b/src/cray/cfs/operator/events/session_events.py
@@ -625,7 +625,6 @@ class CFSSessionController:
                     ),  # V1ObjectMeta
                     spec=client.V1PodSpec(
                         service_account_name=self.env['CRAY_CFS_SERVICE_ACCOUNT'],
-                        priority_class_name= "csm-high-priority-service",
                         restart_policy="Never",
                         volumes=[
                             self._job_volumes['CA_PUBKEY'],


### PR DESCRIPTION
## Summary and Scope

Removes the high priority pod class from CFS sessions so that CFS does not interfere with other services during configuration.

## Issues and Related PRs

* Resolves CASMTRIAGE-4452

## Testing

### Tested on:

  * Shandy

### Test description:

- Full system boot and configurations were run

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

