### PR TITLE
CASMCMS-8313: Fix image customizations for sessions without new imagemap

### DIFF
--- a/src/cray/cfs/inventory/image/__init__.py
+++ b/src/cray/cfs/inventory/image/__init__.py
@@ -207,7 +207,7 @@ class ImageRootInventory(CFSInventoryBase):
         host, port, session = get_IMS_API()
 
         archive_name = ""
-        image_map = session_target.get("imageMap", [])
+        image_map = session_target.get("imageMap") or []
         for mapping in image_map:
             if mapping.get("sourceId", "") == ims_id:
                 archive_name = mapping.get("resultName")


### PR DESCRIPTION
## Summary and Scope

Fixes an issue when the new image map is not defined

## Issues and Related PRs

* Resolves CASMCMS-8313

## Testing

### Tested on:

  * Virtual Shasta

### Test description:

Successfully re-ran an image customization session that had been failing.

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

