### PR TITLE
CASMCMS-8374: Fix container limits by including CASMCMS-8208

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.16.5] - 1/12/23
+### Fixed
+- Fixed configurable session requests/limits
+
 ## [1.16.4] - 1/6/23
 ### Added
 - Add Artifactory authentication to Jenkinsfile

--- a/kubernetes/cray-cfs-operator/templates/configmap.yaml
+++ b/kubernetes/cray-cfs-operator/templates/configmap.yaml
@@ -1,7 +1,7 @@
 {{/*
 MIT License
 
-(C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+(C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -34,6 +34,8 @@ data:
   cray_cfs_util_image: "{{ .Values.util_image.repository }}:{{ .Values.util_image.version }}"
   cray_cfs_aee_image: "{{ .Values.aee_image.repository }}:{{ .Values.aee_image.version }}"
   cray_cfs_ims_image: "{{ .Values.ims_image.repository }}:{{ .Values.ims_image.version | default $baseChartValues.global.appVersion }}"
+  ansible_container_requests: '{"memory": "4Gi", "cpu": "500m"}'
+  ansible_container_limits: '{"memory": "6Gi", "cpu": "8"}'
 
 ---
 apiVersion: v1

--- a/kubernetes/cray-cfs-operator/values.yaml
+++ b/kubernetes/cray-cfs-operator/values.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -68,6 +68,16 @@ cray-service:
           configMapKeyRef:
             name: cray-cfs-operator-config
             key: cray_cfs_aee_image
+      - name: CRAY_CFS_ANSIBLE_CONTAINER_REQUESTS
+        valueFrom:
+          configMapKeyRef:
+            name: cray-cfs-operator-config
+            key: ansible_container_requests
+      - name: CRAY_CFS_ANSIBLE_CONTAINER_LIMITS
+        valueFrom:
+          configMapKeyRef:
+            name: cray-cfs-operator-config
+            key: ansible_container_limits
       - name: CRAY_CFS_CONFIGMAP_PUBLIC_KEY
         value: "cray-configmap-ca-public-key"
       - name: CRAY_CFS_CA_PUBLIC_KEY


### PR DESCRIPTION
## Summary and Scope

Fixes an issue where half of the container limit change was pulled in when changes were made to collapse the Ansible layers.  This pulls in the remainder of the change.

## Issues and Related PRs

* Resolves CASMCMS-8374

## Testing

### Tested on:

  * Wasp

### Test description:

CFS sessions were successfully run

## Risks and Mitigations

None

## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

