### PR TITLE
CASMCMS-8385: Fix issues around cfs-operator downtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.18.0] - 1/12/2023
+## [1.17.1] - 1/25/2023
+### Fixed
+- Increased container memory limits
+- Excluded missing sessions from retries during setup
+
+## [1.17.0] - 1/12/2023
 ### Added
 - Add Artifactory authentication to Jenkinsfile
 - Added a new parameter for naming image customization results

--- a/kubernetes/cray-cfs-operator/values.yaml
+++ b/kubernetes/cray-cfs-operator/values.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -100,7 +100,7 @@ cray-service:
           memory: "150Mi"
           cpu: "200m"
         limits:
-          memory: "250Mi"
+          memory: "500Mi"
           cpu: "500m"
       livenessProbe:
         exec:

--- a/src/cray/cfs/operator/events/job_events.py
+++ b/src/cray/cfs/operator/events/job_events.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -132,7 +132,7 @@ class CFSJobMonitor:
     def session_complete(self, session):
         session_name = session['name']
         if self._session_missing(session_name):
-            LOGGER.warning('Session {} was being monitored but can no longer be found')
+            LOGGER.warning('Session {} was being monitored but can no longer be found'.format(session_name))
             return True
 
         job_name = session['status']['session'].get('job')

--- a/src/cray/cfs/operator/events/session_events.py
+++ b/src/cray/cfs/operator/events/session_events.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -102,7 +102,9 @@ class CFSSessionController:
                 LOGGER.warning('Invalid event type detected: {}'.format(event))
         except Exception as e:
             LOGGER.error("EVENT: Exception while handling cfs-operator event: {}".format(e))
-            self._send_retry(event, kafka)
+            if "404 Client Error" not in str(e):
+                # 404 errors are usually deleted sessions and won't recover
+                self._send_retry(event, kafka)
         kafka.consumer.commit()
 
     def _handle_added(self, event_data):


### PR DESCRIPTION
## Summary and Scope

Addresses issues seen where the cfs-operator when down due memory limits and caused a backlog of session creation requests.  This both increases memory to prevent cfs-operator from exceeding this limit and improves recovery by ignoring old session creation requests.

## Issues and Related PRs

* Resolves CASMCMS-8385
* Resolves CASMCMS-8384

## Testing

### Tested on:

  * Mug

### Test description:

Tested downtime for the cfs-operator with and without the changes, and monitored the memory usage.

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

