### PR TITLE
CASMCMS-8713: Bump PyYAML from 5.4.1 to 6.0.1 to prevent build issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [1.18.1] - 7/18/2023
+### Changed
+- In [`src/cray/cfs/teardown/__main__.py`](src/cray/cfs/teardown/__main__.py), use `yaml.safe_load()`
+  instead of `yaml.load()`, both for security reasons and because the current function call breaks
+  when moving to `PyYAML` >= 6
+
 ### Dependencies
 - Bump `PyYAML` from 5.4.1 to 6.0.1 to avoid build issue caused by https://github.com/yaml/pyyaml/issues/601
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [1.18.1] - 7/18/2023
+### Dependencies
+- Bump `PyYAML` from 5.4.1 to 6.0.1 to avoid build issue caused by https://github.com/yaml/pyyaml/issues/601
 
 ## [1.18.0] - 6/27/2023
 ### Removed

--- a/constraints.txt
+++ b/constraints.txt
@@ -34,7 +34,7 @@ PyNaCl==1.2.1
 pytest==4.2.1
 pytest-cov==2.6.1
 python-dateutil==2.7.5
-PyYAML==5.4.1
+PyYAML==6.0.1
 redis==3.2.1
 requests==2.22.0
 requests-oauthlib==1.0.0

--- a/src/cray/cfs/teardown/__main__.py
+++ b/src/cray/cfs/teardown/__main__.py
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -118,7 +118,7 @@ def _get_targets(session_succeeded: bool) -> Tuple[Iterable, Iterable]:
 def _get_image_to_job() -> Mapping[str, str]:
     """ Return the mapping of image ids to job ids """
     with open('/inventory/image_to_job.yaml', 'r') as i2j_file:
-        image_to_job = yaml.load(i2j_file)
+        image_to_job = yaml.safe_load(i2j_file)
     LOGGER.debug("Fetched image_to_job.yaml: %s", image_to_job)
     return image_to_job
 


### PR DESCRIPTION
Builds in this repo are failing due to the problem documented in [CASMCMS-8713](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8713). Moving to PyYAML 6.0.1 resolves the problem. This PR moves PyYAML from 5.4.1 to 6.0.1.

A similar change is being made to a number of CSM repositories that are similarly affected.

This PR also includes a minor change to one source file, altering a `yaml.load()` function call to `yaml.safe_load()`. This would be a good change to make regardless, for security reasons, but the motivation to include it in this PR specifically is because one of the few breaking changes between PyYAML 5.4 and PyYAML 6 is that the `Loader` argument  to the `yaml.load()` function changed from optional to required, and the function call in this particular source file omits it.