### PR TITLE
CASMCMS-8713: Bump PyYAML from 5.4.1 to 6.0.1 to prevent build issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [1.16.6] - 7/18/23
+### Changed
+- In [`src/cray/cfs/teardown/__main__.py`](src/cray/cfs/teardown/__main__.py), use `yaml.safe_load()`
+  instead of `yaml.load()`, both for security reasons and because the current function call breaks
+  when moving to `PyYAML` >= 6
+
 ### Dependencies
 - Bump `PyYAML` from 5.4.1 to 6.0.1 to avoid build issue caused by https://github.com/yaml/pyyaml/issues/601
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.16.6] - 7/18/23
+### Dependencies
+- Bump `PyYAML` from 5.4.1 to 6.0.1 to avoid build issue caused by https://github.com/yaml/pyyaml/issues/601
+
 ## [1.16.5] - 1/12/23
 ### Fixed
 - Fixed configurable session requests/limits

--- a/constraints.txt
+++ b/constraints.txt
@@ -34,7 +34,7 @@ PyNaCl==1.2.1
 pytest==4.2.1
 pytest-cov==2.6.1
 python-dateutil==2.7.5
-PyYAML==5.4.1
+PyYAML==6.0.1
 redis==3.2.1
 requests==2.22.0
 requests-oauthlib==1.0.0

--- a/src/cray/cfs/teardown/__main__.py
+++ b/src/cray/cfs/teardown/__main__.py
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -118,7 +118,7 @@ def _get_targets(session_succeeded: bool) -> Tuple[Iterable, Iterable]:
 def _get_image_to_job() -> Mapping[str, str]:
     """ Return the mapping of image ids to job ids """
     with open('/inventory/image_to_job.yaml', 'r') as i2j_file:
-        image_to_job = yaml.load(i2j_file)
+        image_to_job = yaml.safe_load(i2j_file)
     LOGGER.debug("Fetched image_to_job.yaml: %s", image_to_job)
     return image_to_job
 


### PR DESCRIPTION
Backport of https://github.com/Cray-HPE/cfs-operator/pull/85 to allow support/1.16 branch to be buildable