### PR TITLE
CASMCMS-8722: Use update_external_versions to get latest patch version of liveness Python module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Dependencies
-- Bump `bcrypt` from 3.1.4 to 3.1.7
-- Bump `cffi` from 1.14.3 to 1.14.6
-- Bump `coverage` from 4.5.2 to 4.5.4
-- Bump `dictdiffer` from 0.8.0 to 0.8.1
-- Bump `google-auth` from 1.6.1 to 1.6.3
-- Bump `Jinja2` from 2.10.1 to 2.10.3
-- Bump `py` from 1.8.0 to 1.8.2
-- Bump `pyasn1` from 0.4.4 to 0.4.8
-- Bump `pyasn1-modules` from 0.2.2 to 0.2.8
-- Bump `rsa` from 4.7 to 4.7.2
-- Bump `urllib3` from 1.25.9 to 1.25.11
+- Use `update_external_versions` to get latest patch version of `liveness` Python module.
+- Bumped dependency patch versions:
+| Package                  | From     | To       |
+|--------------------------|----------|----------|
+| `bcrypt`                 | 3.1.4    | 3.1.7    |
+| `cffi`                   | 1.14.3   | 1.14.6   |
+| `coverage`               | 4.5.2    | 4.5.4    |
+| `dictdiffer`             | 0.8.0    | 0.8.1    |
+| `google-auth`            | 1.6.1    | 1.6.3    |
+| `Jinja2`                 | 2.10.1   | 2.10.3   |
+| `py`                     | 1.8.0    | 1.8.2    |
+| `pyasn1`                 | 0.4.4    | 0.4.8    |
+| `pyasn1-modules`         | 0.2.2    | 0.2.8    |
+| `rsa`                    | 4.7      | 4.7.2    |
+| `urllib3`                | 1.25.9   | 1.25.11  |
 
 ## [1.18.2] - 7/20/2023
 ### Dependencies

--- a/constraints.txt
+++ b/constraints.txt
@@ -16,7 +16,7 @@ idna==2.8
 Jinja2==2.10.3
 kafka-python==2.0.2
 kubernetes==9.0.1
-liveness==1.3.37
+liveness==0.0.0-liveness
 MarkupSafe==1.1.1
 mccabe==0.6.1
 more-itertools==7.0.0

--- a/update_external_versions.conf
+++ b/update_external_versions.conf
@@ -81,3 +81,9 @@
 image: cray-aee
     major: 1
     minor: 4
+
+# This Python module is built in the k8s-liveness repository
+image: liveness
+    source: python
+    major: 1
+    minor: 4

--- a/update_versions.conf
+++ b/update_versions.conf
@@ -36,3 +36,9 @@ sourcefile: cray-aee.version
 tag: 0.0.0-aee
 targetfile: kubernetes/cray-cfs-operator/values.yaml
 targetfile: kubernetes/cray-cfs-operator/Chart.yaml
+
+# The following file does not exist in the repo as a static file
+# It is generated at build time by the runBuildPrep.sh script
+sourcefile: liveness.version
+tag: 0.0.0-liveness
+targetfile: constraints.txt


### PR DESCRIPTION
## Summary and Scope

Now that `update_external_versions` handles Python modules, this update this repo to use it in order to grab the latest patch version of the `liveness` Python module.

(This was prompted by my noticing some cases in other repos where we are using outdated versions of our Python modules)