### PR TITLE
CASMCMS-8790: Add support for cloning from sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [Unreleased]
+### Added
+- Added support for cloning from CFS sources
+
+### Changed
+- CFS session git-clone containers now use the cfs-operator image 
 
 ## [1.21.0] - 9/28/2023
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ WORKDIR /app
 # Upgrade apk-tools and busybox to avoid Snyk-detected security issues
 RUN apk add --upgrade --no-cache apk-tools busybox && \
 	apk update && \
-    apk add --no-cache gcc musl-dev openssh libffi-dev openssl-dev python3-dev py3-pip make curl bash && \
+    apk add --no-cache gcc musl-dev openssh libffi-dev openssl-dev python3-dev py3-pip make curl bash git && \
     apk -U upgrade --no-cache
 ADD constraints.txt requirements.txt /app/
 RUN --mount=type=secret,id=netrc,target=/root/.netrc pip3 install --no-cache-dir -U pip && \
@@ -36,6 +36,7 @@ RUN --mount=type=secret,id=netrc,target=/root/.netrc pip3 install --no-cache-dir
 COPY src/ /app/lib
 COPY .version /app/lib/
 RUN cd /app/lib && pip3 install --no-cache-dir .
+RUN chmod 755 $(python3 -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")/cray/cfs/clone/askpass.py
 
 # Nox Environment
 FROM base as nox

--- a/kubernetes/cray-cfs-operator/templates/configmap.yaml
+++ b/kubernetes/cray-cfs-operator/templates/configmap.yaml
@@ -31,9 +31,8 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ .Values.service_name }}
 data:
-  cray_cfs_util_image: "{{ .Values.util_image.repository }}:{{ .Values.util_image.version }}"
+  cray_cfs_util_image: "{{ .Values.clone_image.repository }}:{{ .Values.clone_image.version | default $baseChartValues.global.appVersion }}"
   cray_cfs_aee_image: "{{ .Values.aee_image.repository }}:{{ .Values.aee_image.version }}"
-  cray_cfs_ims_image: "{{ .Values.ims_image.repository }}:{{ .Values.ims_image.version | default $baseChartValues.global.appVersion }}"
   ansible_container_requests: '{"memory": "4Gi", "cpu": "500m"}'
   ansible_container_limits: '{"memory": "6Gi", "cpu": "8"}'
 
@@ -76,7 +75,7 @@ data:
     [ssh_connection]
     pipelining = True
     ssh_args = -o ServerAliveInterval=30 -o ControlMaster=auto -o ControlPersist=60s
-    
+
     [community.sops]
     vars_stage = all
     vars_cache = true

--- a/kubernetes/cray-cfs-operator/values.yaml
+++ b/kubernetes/cray-cfs-operator/values.yaml
@@ -30,10 +30,9 @@
 #   tag: "" (default = "latest")
 #   pullPolicy: "" (default = "IfNotPresent")
 
-util_image:
-  repository: artifactory.algol60.net/csm-docker/stable/docker.io/alpine/git
-  version: 2.32.0
-ims_image:
+clone_image:
+  repository: artifactory.algol60.net/csm-docker/stable/cray-cfs-operator
+inventory_image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-cfs-operator
 aee_image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-aee
@@ -86,13 +85,10 @@ cray-service:
         value: "cfstrustcertificate"
       - name: CRAY_CFS_TRUST_KEY_SECRET
         value: "cfstrust"
-      - name: CRAY_CFS_IMS_IMAGE
-        valueFrom:
-          configMapKeyRef:
-            name: cray-cfs-operator-config
-            key: cray_cfs_ims_image
       - name: CRAY_CFS_SERVICE_ACCOUNT
         value: "cray-cfs"
+      - name: VAULT_ADDR
+        value: "http://cray-vault.vault:8200"
       - name: VCS_USER_CREDENTIALS
         value: "vcs-user-credentials"
       resources:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ redis
 liveness
 kafka-python
 ujson
+hvac
+gitpython

--- a/src/cray/cfs/clone/__init__.py
+++ b/src/cray/cfs/clone/__init__.py
@@ -1,7 +1,8 @@
+#!/usr/bin/env python
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -21,31 +22,3 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
-apiVersion: v2
-name: cray-cfs-operator
-version: 0.0.0-chart
-description: Kubernetes resources for cfs-operator
-keywords:
-- cfs
-- cray-cfs-operator
-home: https://github.com/Cray-HPE/cfs-operator
-sources:
-- https://github.com/Cray-HPE/cfs-operator
-- https://github.com/Cray-HPE/ansible-execution-environment
-dependencies:
-- name: cray-service
-  version: ^7.0.0
-  repository: https://artifactory.algol60.net/artifactory/csm-helm-charts/
-maintainers:
-- name: rbak-hpe
-  email: ryan.bak@hpe.com
-- name: rkleinman-hpe
-  email: randy.kleinman@hpe.com
-appVersion: 0.0.0-image
-annotations:
-  artifacthub.io/images: |
-    - name: cray-cfs-operator
-      image: artifactory.algol60.net/csm-docker/stable/cray-cfs-operator:0.0.0-image
-    - name: cray-aee
-      image: artifactory.algol60.net/csm-docker/stable/cray-aee:0.0.0-aee
-  artifacthub.io/license: MIT

--- a/src/cray/cfs/clone/__main__.py
+++ b/src/cray/cfs/clone/__main__.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+"""
+CFS Clone - module to clone down git content as part of a CFS Session for use with
+the Ansible Execution Environment.
+"""
+import logging
+import os
+import sys
+import time
+
+import git
+
+from cray.cfs.logging import setup_logging, update_logging
+import cray.cfs.operator.cfs.configurations as cfs_configurations
+import cray.cfs.operator.cfs.sources as cfs_sources
+import cray.cfs.operator.cfs.options as cfs_options
+from cray.cfs.utils import apply_configuration_limit
+from cray.cfs.utils.kubernetes_utils import get_configmap
+
+LOGGER = logging.getLogger("cray.cfs.clone")
+
+SHARED_DIRECTORY = "/inventory"
+
+
+def main():
+    LOGGER.info("Starting CFS Clone")
+    retry_limit=int(os.environ.get("GIT_RETRY_MAX", 60))
+    retry_delay=int(os.environ.get("GIT_RETRY_DELAY", 10))
+
+    configuration_name = os.environ["SESSION_CONFIGURATION_NAME"]
+    configuration_limit = os.environ["SESSION_CONFIGURATION_LIMIT"]
+    try:
+        configuration = cfs_configurations.get_configuration(configuration_name)
+    except Exception as e:
+        if configuration_name.startswith("debug_"):
+            # There is nothing to clone for debug playbooks
+            return
+        raise e
+
+    configuration_layers = configuration.get("layers", [])
+    repos = [("layer"+i, layer) for i, layer in apply_configuration_limit(configuration_layers, configuration_limit)]
+
+    additional_inventory = configuration.get("additional_inventory", {})
+    if not additional_inventory:
+        if cfs_options.options.additional_inventory_source:
+            additional_inventory = {"source": cfs_options.options.additional_inventory_source, "commit": ""}
+        elif cfs_options.options.additional_inventory_url:
+            additional_inventory = {"clone_url": cfs_options.options.additional_inventory_source, "commit": ""}
+    if additional_inventory:
+        repos.append(("hosts", additional_inventory))
+
+    for repo_dir, repo_info in repos:
+        source_name = repo_info.get("source")
+        source = None
+        if source_name:
+            source = cfs_sources.get_source(source_name)
+            clone_url = source["clone_url"]
+        else:
+            clone_url = repo_info["clone_url"]
+        commit = repo_info.get("commit")
+        clone_repo(clone_url, repo_dir, commit=commit, source=source, retry_limit=retry_limit, retry_delay=retry_delay)
+
+    return 0
+
+
+def clone_repo(clone_url, repo_directory, commit=None, source=None, retry_limit=1, retry_delay=10):
+    try:
+        ssl_info = _get_ssl_info(source)
+    except Exception as e:
+        LOGGER.error(f"Error retrieving git CA cert info: {e}")
+        raise
+
+    project_dir = os.path.dirname(os.path.abspath(__file__))
+    git_askpass = os.path.join(project_dir, "askpass.py")
+    clone_env = {"GIT_ASKPASS": git_askpass, "GIT_SSL_CAINFO": ssl_info}
+    if source:
+         clone_env["SECRET_NAME"] = source.get("credentials").get("secret_name", "")
+
+    x = 1
+    while True:
+        try:
+            repo = git.Repo.clone_from(clone_url, os.path.join(SHARED_DIRECTORY, repo_directory), env=clone_env)
+            LOGGER.info(f"Successfully cloned repo {clone_url}")
+            break
+        except Exception as e:
+            if x == 1:
+                LOGGER.warning(e)
+            if x < retry_limit:
+                LOGGER.info("Cloning failed - Retrying")
+                x = x + 1
+                time.sleep(retry_delay)
+            else:
+                LOGGER.error("Cloning exceeded retry limit")
+                raise
+
+    if commit:
+        try:
+            repo.git.checkout(commit)
+        except Exception as e:
+            LOGGER.error(f"Exception checking out commit {commit} for repo {clone_url}")
+            raise
+        LOGGER.info(f"Successfully checked out commit {commit} for repo {clone_url}")
+
+
+def _get_ssl_info(source=None, tmp_dir="/tmp"):
+    if source and source.get("ca_cert"):
+        cert_info = source.get("ca_cert")
+        configmap_name = cert_info["configmap_name"]
+        configmap_namespace = cert_info.get("configmap_namespace")
+        if configmap_namespace:
+            response = get_configmap(configmap_name, configmap_namespace)
+        else:
+            response = get_configmap(configmap_name)
+        data = response.data
+        file_name = list(data.keys())[0]
+        file_path = os.path.join(tmp_dir, file_name)
+        with open(file_path, "w") as f:
+            f.write(data[file_name])
+        return file_path
+    else:
+        return os.environ["GIT_SSL_CAINFO"]
+
+
+if __name__ == "__main__":
+    setup_logging()
+    update_logging(update_options=True)
+    exit_code = 0
+    try:
+        exit_code = main()
+    except Exception as e:
+        LOGGER.exception(e)
+        exit_code = 1
+    sys.exit(exit_code)

--- a/src/cray/cfs/clone/askpass.py
+++ b/src/cray/cfs/clone/askpass.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+
+# Intended to be called by Git via GIT_ASKPASS.
+
+import os
+import sys
+
+from cray.cfs.utils.vault_utils import get_secret as get_vault_secret
+
+def _get_git_credentials():
+    secret_name = os.environ.get('SECRET_NAME')
+    if not secret_name:
+        username = os.environ['VCS_USERNAME'].strip()
+        password = os.environ['VCS_PASSWORD'].strip()
+        return username, password
+    try:
+        secret = get_vault_secret(secret_name)
+    except Exception as e:
+        raise Exception(f"Error loading Vault secret: {e}") from e
+    try:
+        username = secret["username"]
+        password = secret["password"]
+    except Exception as e:
+        raise Exception(f"Error reading username and password from secret: {e}") from e
+    return username, password
+
+def main():
+    username, password = _get_git_credentials()
+    if 'username' in sys.argv[1].lower():
+        print(username)
+        exit()
+    if 'password' in sys.argv[1].lower():
+        print(password)
+        exit()
+    exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/src/cray/cfs/operator/cfs/options.py
+++ b/src/cray/cfs/operator/cfs/options.py
@@ -35,6 +35,7 @@ ENDPOINT = "%s/%s" % (BASE_ENDPOINT, __name__.lower().split('.')[-1])
 DEFAULTS = {
     'session_ttl': '7d',
     'additional_inventory_url': '',
+    'additional_inventory_source': '',
     'logging_level': 'INFO',
     'debug_wait_time': 3600
 }
@@ -107,6 +108,10 @@ class Options:
     @property
     def additional_inventory_url(self):
         return self.get_option('additional_inventory_url', str)
+
+    @property
+    def additional_inventory_source(self):
+        return self.get_option('additional_inventory_source', str)
 
     @property
     def logging_level(self):

--- a/src/cray/cfs/operator/cfs/sources.py
+++ b/src/cray/cfs/operator/cfs/sources.py
@@ -1,0 +1,61 @@
+#
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
+import ujson as json
+import logging
+from requests.exceptions import HTTPError, ConnectionError
+from urllib3.exceptions import MaxRetryError
+import urllib.parse
+
+from . import requests_retry_session
+from . import ENDPOINT as BASE_ENDPOINT
+
+LOGGER = logging.getLogger(__name__)
+ENDPOINT = "%s/%s" % (BASE_ENDPOINT, __name__.lower().split('.')[-1])
+
+
+def get_source(source_name):
+    """Get information for a single CFS source"""
+    url = ENDPOINT + '/' + _encode_source_name(source_name)
+    session = requests_retry_session()
+    try:
+        response = session.get(url)
+        response.raise_for_status()
+        cfs_source = json.loads(response.text)
+    except (ConnectionError, MaxRetryError) as e:
+        LOGGER.error("Unable to connect to CFS: {}".format(e))
+        raise e
+    except HTTPError as e:
+        LOGGER.error("Unexpected response from CFS: {}".format(e))
+        raise e
+    except json.JSONDecodeError as e:
+        LOGGER.error("Non-JSON response from CFS: {}".format(e))
+        raise e
+    return cfs_source
+
+def _encode_source_name(source_name):
+    # Quote twice.  One level of decoding is automatically done the API framework, so one level of encoding
+    # produces the same problems as not encoding at all.
+    source_name = urllib.parse.quote(source_name, safe='')
+    source_name = urllib.parse.quote(source_name, safe='')
+    return source_name

--- a/src/cray/cfs/utils/__init__.py
+++ b/src/cray/cfs/utils/__init__.py
@@ -91,3 +91,18 @@ def wait_for_aee_finish(cfs_name, cfs_namespace):  # noqa: C901
             time.sleep(5)
             continue
     return ansible_status.exit_code
+
+
+def apply_configuration_limit(configuration_layers: list, configuration_limit: str) -> list[tuple[str, dict]]:
+        if configuration_limit:
+            limits = configuration_limit.split(',')
+            if all([x.isdigit() for x in limits]):
+                limits = [int(x) for x in limits]
+                configuration = [(str(x), configuration_layers[x]) for x in sorted(limits)
+                                 if (0 < x < len(configuration_layers))]
+            else:
+                configuration = [(str(i), layer) for i, layer in enumerate(configuration_layers)
+                                 if layer.get('name', '') in configuration_limit]
+        else:
+            configuration = [(str(i), layer) for i, layer in enumerate(configuration_layers)]
+        return configuration

--- a/src/setup.py
+++ b/src/setup.py
@@ -41,6 +41,7 @@ setup(
     url="https://github.com/Cray-HPE/cfs-operator",
     packages=find_namespace_packages(
         include=(
+            'cray.cfs.clone',
             'cray.cfs.inventory',
             'cray.cfs.inventory.image',
             'cray.cfs.logging',


### PR DESCRIPTION
## Summary and Scope

Adds support for the new CFS "sources".  This allows users to specify repos, as well as their credentials and ca certs, so that CFS can access Ansible content outside the standard VCS.

Part of this change required switching the git-clone container to using the cfs-operator image so that credentials could be accessed securely.

## Issues and Related PRs

* Resolves CASMCMS-8790

## Testing

### Tested on:

  * Mug

### Test description:

- Tested updating, patching and deleting various sources.
- Tested adding configurations with branches, with and without sources (so the branch was converted in the API)
- Tested CFS sessions using configurations with and without sources.

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

