### PR TITLE
CASMTRIAGE-6195: Fix config limit for layer 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.22.1] - 10/23/2023
+### Fixed
+- Fixed applying the configuration limit for layer 0
+
 ## [1.22.0] - 10/18/2023
 ### Added
 - Added support for cloning from CFS sources

--- a/src/cray/cfs/utils/__init__.py
+++ b/src/cray/cfs/utils/__init__.py
@@ -99,7 +99,7 @@ def apply_configuration_limit(configuration_layers: list, configuration_limit: s
             if all([x.isdigit() for x in limits]):
                 limits = [int(x) for x in limits]
                 configuration = [(str(x), configuration_layers[x]) for x in sorted(limits)
-                                 if (0 < x < len(configuration_layers))]
+                                 if (0 <= x < len(configuration_layers))]
             else:
                 configuration = [(str(i), layer) for i, layer in enumerate(configuration_layers)
                                  if layer.get('name', '') in configuration_limit]


### PR DESCRIPTION
## Summary and Scope

Fixes the code to apply configuration limits so that layer 0 is not missed when a config limit is specified.

## Issues and Related PRs

* Resolves CASMTRIAGE-6195

## Testing

### Tested on:

  * beau
### Test description:

Successfully ran a job that had previously been failing.

## Risks and Mitigations

None


## Pull Request Checklist

- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable
- [X] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

