### PR TITLE
CASMCMS-8896 - update image inventory to authenticate ssh connection.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.24.0] - 03/01/2024
+### Changed
 - CASMCMS-8896 - enhance the ssh test for if the connection is ready for use.
 
 ## [1.23.0] - 02/22/2024

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+- CASMCMS-8896 - enhance the ssh test for if the connection is ready for use.
+
 ## [1.22.1] - 10/23/2023
 ### Fixed
 - Fixed applying the configuration limit for layer 0


### PR DESCRIPTION
## Summary and Scope

The inventory container was only waiting until the ssh connection was responding, not fully functional. This was leading to cases where it passes control to the ansible container, where ansible was assuming the connection was ready to go. In fact it was not ready, so would fail immediately. This does the deeper connection check at the inventory step so the ssh connection is ready when the ansible container starts to use it. 

## Issues and Related PRs
* Resolves [CASMCMS-8896](https://jira-pro.it.hpe.com:8443/browse/CASMCMS-8896)

## Testing
### Tested on:
  * `Mug`

### Test description:

I updated the new cfs-operator image into the CFS job config map and tested the remote jobs waiting for this connection to be fully functional

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? N
- Was upgrade tested? If not, why? N
- Was downgrade tested? If not, why? N
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

This should be a fairly minor change.

## Pull Request Checklist
- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

