### PR TITLE
CASMCMS-8914: Use appropriate version of Python k8s client for CSM 1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Dependencies
+- Bump `kubernetes` from 9.0.1 to 22.6.0 to match CSM 1.6 Kubernetes version
+
 ## [1.22.1] - 10/23/2023
 ### Fixed
 - Fixed applying the configuration limit for layer 0

--- a/constraints.txt
+++ b/constraints.txt
@@ -15,7 +15,8 @@ google-auth==1.6.3
 idna==2.8
 Jinja2==2.10.3
 kafka-python==2.0.2
-kubernetes==9.0.1
+# CSM 1.6 uses Kubernetes 1.22, so use client v22.x to ensure compatability
+kubernetes==22.6.0
 liveness==0.0.0-liveness
 MarkupSafe==1.1.1
 mccabe==0.6.1


### PR DESCRIPTION
I noticed that some of our Python code for CSM 1.6 is pulling in non-optimal versions of the Kubernetes client library. Ideally the major version of the library should correspond to the Kubernetes version on the system, but in many cases it is not. This doesn't guarantee that there will be problems, but it's least risky to use the appropriate version.

This problem also exists in past CSM versions, but this is not the kind of thing worth backporting without additional reason, so I'll just confine my change to CSM 1.6.
