### PR TITLE
CASMCMS-9018: Bump paramiko version to avoid Blowfish deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- When building unstable charts, have them point to the corresponding unstable cfs-operator images
+
 ### Dependencies
 - CASMCMS-9018/CAST-35618: Bump `paramiko` from 2.7.2 to 2.11.1 to prevent Blowfish deprecation warnings.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Dependencies
+- CASMCMS-9018/CAST-35618: Bump `paramiko` from 2.7.2 to 2.11.1 to prevent Blowfish deprecation warnings.
 
 ## [1.24.0] - 03/01/2024
 ### Changed

--- a/constraints.txt
+++ b/constraints.txt
@@ -23,7 +23,7 @@ mccabe==0.6.1
 more-itertools==7.0.0
 nox==2018.10.17
 oauthlib==2.1.0
-paramiko==2.7.2
+paramiko==2.11.1
 pluggy==0.8.1
 py==1.8.2
 pyasn1==0.4.8

--- a/kubernetes/cray-cfs-operator/Chart.yaml
+++ b/kubernetes/cray-cfs-operator/Chart.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2022, 2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -45,7 +45,7 @@ appVersion: 0.0.0-image
 annotations:
   artifacthub.io/images: |
     - name: cray-cfs-operator
-      image: artifactory.algol60.net/csm-docker/stable/cray-cfs-operator:0.0.0-image
+      image: artifactory.algol60.net/csm-docker/S-T-A-B-L-E/cray-cfs-operator:0.0.0-image
     - name: cray-aee
       image: artifactory.algol60.net/csm-docker/stable/cray-aee:0.0.0-aee
   artifacthub.io/license: MIT

--- a/kubernetes/cray-cfs-operator/values.yaml
+++ b/kubernetes/cray-cfs-operator/values.yaml
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2021-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -31,9 +31,9 @@
 #   pullPolicy: "" (default = "IfNotPresent")
 
 clone_image:
-  repository: artifactory.algol60.net/csm-docker/stable/cray-cfs-operator
+  repository: artifactory.algol60.net/csm-docker/S-T-A-B-L-E/cray-cfs-operator
 inventory_image:
-  repository: artifactory.algol60.net/csm-docker/stable/cray-cfs-operator
+  repository: artifactory.algol60.net/csm-docker/S-T-A-B-L-E/cray-cfs-operator
 aee_image:
   repository: artifactory.algol60.net/csm-docker/stable/cray-aee
   version: 0.0.0-aee
@@ -51,7 +51,7 @@ cray-service:
     cray-cfs-operator:
       name: cray-cfs-operator
       image:
-        repository: artifactory.algol60.net/csm-docker/stable/cray-cfs-operator
+        repository: artifactory.algol60.net/csm-docker/S-T-A-B-L-E/cray-cfs-operator
       env:
       - name: CFS_OPERATOR_LOG_LEVEL
         value: "INFO"

--- a/update_versions.conf
+++ b/update_versions.conf
@@ -42,3 +42,10 @@ targetfile: kubernetes/cray-cfs-operator/Chart.yaml
 sourcefile: liveness.version
 tag: 0.0.0-liveness
 targetfile: constraints.txt
+
+# This allows unstable charts to reference unstable images and be usable
+# without modification when testing them
+sourcefile-novalidate: .stable
+tag: S-T-A-B-L-E
+targetfile: kubernetes/cray-cfs-operator/values.yaml
+targetfile: kubernetes/cray-cfs-operator/Chart.yaml


### PR DESCRIPTION
[CAST-35618](https://jira-pro.it.hpe.com:8443/browse/CAST-35618) was open because a customer saw `CryptographyDeprecationWarning`s in their CFS image customization pod logs. Investigating revealed that a small bump to the paramiko version resolves this. I verified I was able to recreate the original problem on mug, applied this fix, and then verified that the problem no longer occurs (but that the image customization still succeeds).

I also included in this PR a change that has been made to most of the other CMS repos, making the unstable cfs-operator charts point to the corresponding unstable cfs-operator images. This simplifies testing from development branches.

There will be a backport PR for this to CSM 1.5, where the problem was reported.