### PR TITLE
CASMPET-7064 - update cray-service base chart.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Dependencies
-- CSM 1.6 moved to Kubernetes 1.24, so use client v24.x to ensure compatability
+- CSM 1.6 moved to Kubernetes 1.24, so use client v24.x to ensure compatibility
+- CASMPET-7064 - update to cray-services:11.0.0 base chart
 
 ## [1.26.3] - 08/23/2024
 ### Dependencies

--- a/kubernetes/cray-cfs-operator/Chart.yaml
+++ b/kubernetes/cray-cfs-operator/Chart.yaml
@@ -34,7 +34,7 @@ sources:
 - https://github.com/Cray-HPE/ansible-execution-environment
 dependencies:
 - name: cray-service
-  version: ^7.0.0
+  version: ~11.0.0
   repository: https://artifactory.algol60.net/artifactory/csm-helm-charts/
 maintainers:
 - name: rbak-hpe


### PR DESCRIPTION
## Summary and Scope

Update the cray-service chart version to the newest version to pick up changes needed for the updated k8s being deployed with csm 1.6.0.

## Issues and Related PRs
* Resolves [CASMPET-7064](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7064)

## Testing
### Tested on:
  * `Fanta`

### Test description:

Installed the new version via helm (along with updated cfs-batcher), ran through image customization and post-boot personalization workflows. Also ran the cmsdev CT tests before and after the upgrade. Everything worked as expected.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? N
- Were continuous integration tests run? If not, why? Y
- Was upgrade tested? If not, why? Y
- Was downgrade tested? If not, why? Y
- Were new tests (or test issues/Jiras) created for this change? N

## Risks and Mitigations

Required to match the version of k8s being shipped with csm 1.6.0

## Pull Request Checklist
- [X] Version number(s) incremented, if applicable
- [X] Copyrights updated
- [X] License file intact
- [X] Target branch correct
- [X] CHANGELOG.md updated
- [X] Testing is appropriate and complete, if applicable

