### PR TITLE
Feature/casmcms 9261

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Updated cfs-api clusterrole definition to allow it to introspect into tenant namespaces for access to secrets
+### Added
+- Allow session_events to perform VAULT_TOKEN lookups when associated with a configset owned by a tenant
 
 ## [1.28.0] - 01/22/2025
 ### Changed

--- a/kubernetes/cray-cfs-operator/templates/clusterrole.yaml
+++ b/kubernetes/cray-cfs-operator/templates/clusterrole.yaml
@@ -1,7 +1,7 @@
 {{/*
 MIT License
 
-(C) Copyright 2021-2023 Hewlett Packard Enterprise Development LP
+(C) Copyright 2021-2025 Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -50,6 +50,7 @@ rules:
   - secrets
   verbs:
   - get
+  - list
 - apiGroups:
   - "policy"
   resources:
@@ -78,3 +79,9 @@ rules:
   verbs:
   - get
   - list
+- apiGroups:
+  - "tapms.hpe.com"
+  resources:
+  - "tenants"
+  verbs:
+  - get

--- a/src/cray/cfs/operator/events/session_events.py
+++ b/src/cray/cfs/operator/events/session_events.py
@@ -316,7 +316,7 @@ class CFSSessionController:
             # Now that we have the access token for the user, we can use it to login to vault
             vault_login_uri = 'http://cray-vault.vault.svc:8200/v1/auth/kubernetes/login'
             try:
-                vault_response = requestes.put(vault_login_uri, data={'jwt': access_token, 'role': transit_engine}).json()
+                vault_response = requests.put(vault_login_uri, data={'jwt': access_token, 'role': transit_engine}).json()
             except Exception as exception:
                 raise VaultException("Unable to login to complete PUT to Vault Login.") from exception
             LOGGER.info("Vault Response: %s", vault_response)

--- a/src/cray/cfs/operator/events/session_events.py
+++ b/src/cray/cfs/operator/events/session_events.py
@@ -274,6 +274,7 @@ class CFSSessionController:
         except MultitenantException as mte:
             LOGGER.warning("Unable to set VAULT_TOKEN for job: %s; skipping, but could cause failed configuration session.",
                            mte)
+            raise MultitenantException("IT BROKE!") from mte
 
 
     def _set_vault_token(self, session_data):

--- a/src/cray/cfs/operator/events/session_events.py
+++ b/src/cray/cfs/operator/events/session_events.py
@@ -541,6 +541,7 @@ class CFSSessionController:
                            mte)
             # Zero it out, indicating we couldn't look it up, but we tried.
             vault_token_env = client.V1EnvVar(name="VAULT_TOKEN", value='')
+            raise MultitenantException("BROKEN, WHY?") from mte
 
         ansible_container = client.V1Container(
             name='ansible',

--- a/src/cray/cfs/operator/events/session_events.py
+++ b/src/cray/cfs/operator/events/session_events.py
@@ -270,13 +270,13 @@ class CFSSessionController:
             value=str(os.environ.get("VAULT_ADDR", ""))
         )
         try:
-            self._set_vault_token()
+            self._set_vault_token(session_data)
         except MultitenantException as mte:
             LOGGER.warning("Unable to set VAULT_TOKEN for job: %s; skipping, but could cause failed configuration session.",
                            mte)
 
 
-    def _set_vault_token(self):
+    def _set_vault_token(self, session_data):
         """
         When a new CFS Session is created, check to see if the session is being initialized against a configuration
         that it is owned by a specific tenant. If it is owned by a tenant, we need to pass in the unlock token

--- a/src/cray/cfs/operator/events/session_events.py
+++ b/src/cray/cfs/operator/events/session_events.py
@@ -276,16 +276,12 @@ class CFSSessionController:
         that it is owned by a specific tenant. If it is owned by a tenant, we need to pass in the unlock token
         that is required for SOPS to decrypt any encrypted variables.
         """
-        #LOGGER.info("Session Data: %s", session_data)
-        # {'ansible': {'config': 'cfs-default-ansible-cfg', 'limit': None, 'passthrough': None, 'verbosity': 0},
-        # 'configuration': {'limit': '', 'name': 'sleep_blue'}, 'debug_on_failure': False, 'logs': None, 'name': 'sleepblue', 'status': {'artifacts': [], 'session': {'completion_time': None, 'ims_job': None, 'job': 'cfs-9037b0fa-0084-47bc-95b5-6d8993c99f38', 'start_time': '2025-02-11T17:13:42', 'status': 'pending', 'succeeded': 'none'}}, 'tags': {}, 'target': {'definition': 'dynamic', 'groups': [], 'image_map': []}}
         cfs_configuration_name = session_data['configuration']['name']
         try:
             configuration_data = get_configuration(cfs_configuration_name)
         except Exception as exception:
             raise CFSApiException("Unable to obtain configuration information from CFS API.") from exception
         tenant = tenant_namespace = configuration_data.get('tenant_name', None)
-        LOGGER.info("Tenant: %s", tenant)
         if tenant:
             # Once we know there is a tenant associated with it, we need to ask TAPMS about that tenant's transit engine
             try:
@@ -297,7 +293,6 @@ class CFSSessionController:
             except Exception as exception:
                 raise TapmsException("Unable to get namespaced CRD information from TAPMS") from exception
             transit_engine = tapms_response['status']['tenantkms']['transitname']
-            LOGGER.info("Transit Engine: %s", transit_engine)
             # Now, we must read the secret that is associated with the tenant from its' namespace so that we can
             # use it to authenticate to vault. Unfortunately, the name isn't pre-determined, but there should only be
             # exactly one of them, so we must first list all of the defined secrets, and then reference the only one
@@ -312,14 +307,12 @@ class CFSSessionController:
                 raise K8sException("Exactly one secret within tenant namespace '%s' expected; instead found %s."
                                      %(tenant_namespace, secrets_within_tenant))
             access_token = base64.b64decode(tenant_namespaced_secrets_list[0]['data']['token']).decode('ascii')
-            LOGGER.info("Access Token: %s", access_token)
             # Now that we have the access token for the user, we can use it to login to vault
             vault_login_uri = 'http://cray-vault.vault.svc:8200/v1/auth/kubernetes/login'
             try:
                 vault_response = requests.put(vault_login_uri, data={'jwt': access_token, 'role': transit_engine}).json()
             except Exception as exception:
                 raise VaultException("Unable to login to complete PUT to Vault Login.") from exception
-            LOGGER.info("Vault Response: %s", vault_response)
             vault_token = vault_response['auth']['client_token']
             # Finally, with a tenant's vault token in hand, we can append it to the job launch's variables
             return vault_token

--- a/src/cray/cfs/operator/events/session_events.py
+++ b/src/cray/cfs/operator/events/session_events.py
@@ -282,8 +282,10 @@ class CFSSessionController:
         that it is owned by a specific tenant. If it is owned by a tenant, we need to pass in the unlock token
         that is required for SOPS to decrypt any encrypted variables.
         """
-        LOGGER.info("Session Data: %s", session_data)
-        cfs_configuration_name = session_data['ansible']['config']
+        #LOGGER.info("Session Data: %s", session_data)
+        # {'ansible': {'config': 'cfs-default-ansible-cfg', 'limit': None, 'passthrough': None, 'verbosity': 0},
+        # 'configuration': {'limit': '', 'name': 'sleep_blue'}, 'debug_on_failure': False, 'logs': None, 'name': 'sleepblue', 'status': {'artifacts': [], 'session': {'completion_time': None, 'ims_job': None, 'job': 'cfs-9037b0fa-0084-47bc-95b5-6d8993c99f38', 'start_time': '2025-02-11T17:13:42', 'status': 'pending', 'succeeded': 'none'}}, 'tags': {}, 'target': {'definition': 'dynamic', 'groups': [], 'image_map': []}}
+        cfs_configuration_name = session_data['configuration']['name']
         try:
             configuration_data = get_configuration(cfs_configuration_name)
         except Exception as exception:

--- a/src/cray/cfs/operator/events/session_events.py
+++ b/src/cray/cfs/operator/events/session_events.py
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2019-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2019-2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -31,6 +31,8 @@ import shlex
 import time
 import threading
 import uuid
+import base64
+import requests
 
 from kubernetes import client, config
 from kubernetes.client.rest import ApiException
@@ -57,6 +59,37 @@ except ConfigException:  # pragma: no cover
 
 _api_client = client.ApiClient()
 k8sjobs = client.BatchV1Api(_api_client)
+CRD_CLIENT = client.CustomObjectsApi()
+CORE_CLIENT = client.CoreV1Api()
+
+
+class MultitenantException(Exception):
+    """
+    While working with a microservice required for establishing a KV Store for multitenancy, something unexpected
+    happened.
+    """
+
+class CFSApiException(MultitenantException):
+    """
+    When the CFS API is unable to return information in a timely manner.
+    """
+
+
+class TapmsException(MultitenantException):
+    """
+    There was an error while inquiring about the tenant associated with a configuration.
+    """
+
+class K8sException(MultitenantException):
+    """
+    When looking up information from k8s for multitenancy where k8s doesn't behave as expected.
+    """
+
+class VaultException(MultitenantException):
+    """
+    There was an error while interacting with the vault instance.
+    """
+
 
 # Boilerplate code to wait for the envoy sidecar to open connections to the
 # mesh. Calls within pods prior to this completing will fail with connection
@@ -236,6 +269,62 @@ class CFSSessionController:
             name='VAULT_ADDR',
             value=str(os.environ.get("VAULT_ADDR", ""))
         )
+        try:
+            self._set_vault_token()
+        except MultitenantException as mte:
+            LOGGER.warning("Unable to set VAULT_TOKEN for job: %s; skipping, but could cause failed configuration session.",
+                           mte)
+
+
+    def _set_vault_token(self):
+        """
+        When a new CFS Session is created, check to see if the session is being initialized against a configuration
+        that it is owned by a specific tenant. If it is owned by a tenant, we need to pass in the unlock token
+        that is required for SOPS to decrypt any encrypted variables.
+        """
+        cfs_configuration_name = session_data['ansible']['config']
+        try:
+            configuration_data = get_configuration(cfs_configuration_name)
+        except Exception as exception:
+            raise CFSApiException("Unable to obtain configuration information from CFS API.") from exception
+        tenant = tenant_namespace = configuration_data.get('tenant_name', None)
+        if tenant:
+            # Once we know there is a tenant associated with it, we need to ask TAPMS about that tenant's transit engine
+            try:
+                tapms_response = CRD_CLIENT.get_namespaced_custom_object(group='tapms.hpe.com',
+                                                                         version='v1alpha3',
+                                                                         namespace='tenants',
+                                                                         plural='tenants',
+                                                                         name=tenant)
+            except Exception as exception:
+                raise TapmsException("Unable to get namespaced CRD information from TAPMS") from exception
+            transit_engine = tapms_response['status']['tenantkms']['transitname']
+            # Now, we must read the secret that is associated with the tenant from its' namespace so that we can
+            # use it to authenticate to vault. Unfortunately, the name isn't pre-determined, but there should only be
+            # exactly one of them, so we must first list all of the defined secrets, and then reference the only one
+            # that exists.
+            try:
+                tenant_namespaced_secrets_list = CORE_CLIENT.list_namespaced_secret(tenant_namespace).to_dict()['items']
+            except Exception as exception:
+                raise K8sException("Unable to list secrets from tenant's namespace.") from exception
+            # There _should_ be exactly one. If there is any other number, we shouldn't assume.
+            secrets_within_tenant = len(tenant_namespaced_secrets_list)
+            if secrets_within_tenant != 1:
+                raise K8sException("Exactly one secret within tenant namespace '%s' expected; instead found %s."
+                                     %(tenant_namespace, secrets_within_tenant))
+            access_token = base64.b64decode(tenant_namespaced_secrets_list[0]['data']['token']).decode('ascii')
+            # Now that we have the access token for the user, we can use it to login to vault
+            vault_login_uri = 'http://cray-vault.vault.svc:8200/v1/auth/kubernetes/login'
+            try:
+                vault_response = requestes.put(vault_login_uri, data={'jwt': access_token, 'role': transit_engine}).json()
+            except Exception as exception:
+                raise VaultException("Unable to login to complete PUT to Vault Login.") from exception
+            vault_token = vault_response['auth']['client_token']
+            # Finally, with a tenant's vault token in hand, we can append it to the job launch's variables
+            self._job_env['VAULT_TOKEN'] = client.V1EnvVar(
+                name='VAULT_TOKEN',
+                value=vault_token
+            )
 
     def _set_volume_mounts(self):
         """

--- a/src/cray/cfs/operator/events/session_events.py
+++ b/src/cray/cfs/operator/events/session_events.py
@@ -538,7 +538,6 @@ class CFSSessionController:
                            mte)
             # Zero it out, indicating we couldn't look it up, but we tried.
             vault_token_env = client.V1EnvVar(name="VAULT_TOKEN", value='')
-            raise MultitenantException("BROKEN, WHY?") from mte
 
         ansible_container = client.V1Container(
             name='ansible',

--- a/src/cray/cfs/operator/events/session_events.py
+++ b/src/cray/cfs/operator/events/session_events.py
@@ -282,6 +282,7 @@ class CFSSessionController:
         that it is owned by a specific tenant. If it is owned by a tenant, we need to pass in the unlock token
         that is required for SOPS to decrypt any encrypted variables.
         """
+        LOGGER.info("Session Data: %s", session_data)
         cfs_configuration_name = session_data['ansible']['config']
         try:
             configuration_data = get_configuration(cfs_configuration_name)


### PR DESCRIPTION
## Summary and Scope

This mod instructs CFS-Operator to lookup VAULT_TOKENs for any configurations used during the creation of a CFS session that uses a CFS configuration that is owned by a specific tenant.

## Issues and Related PRs
* Resolves [CASMCMS-926]1(https://jira-pro.it.hpe.com:8443/browse/CASMCMS-9261)
* Change will also be needed in a release branch with a tag.

## Testing

### Tested on:

  * `mug`
  * Local development environment

### Test description:
deployed onto mug with similar patchsets to CFS API. Created a config set using a tenant, verified the configset was owned by a tenant. Then created a brand new CFS session and verified that the lookup operations were going to vault and the correct environment variable was set within the created k8s job podspec. Verified that ansible was able to use the created vault address endpoint to decrypt SOPS encrypted variables during the run.

## Risks and Mitigations

None.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable

