### PR TITLE
CASMCMS-9452:Cleanup of leftover Cluster/RoleBindings under CMS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- CASMCMS-9452: Cleanup of leftover Cluster/RoleBindings under CMS
+
 ## [1.30.0] - 04/24/2025
 ### Fixed
 - CASMCMS-9335: cfs session patch fails to update Job ID causing session to remain in pending state.

--- a/kubernetes/cray-cfs-operator/templates/rolebinding.yaml
+++ b/kubernetes/cray-cfs-operator/templates/rolebinding.yaml
@@ -1,7 +1,7 @@
 {{/*
 MIT License
 
-(C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+(C) Copyright 2021-2025 Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -37,6 +37,7 @@ subjects:
     namespace: services
 ---
 # cray-cfs-operator pod needs to run as root
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -50,3 +51,4 @@ subjects:
   - kind: ServiceAccount
     name: cray-cfs
     namespace: services
+{{- end }}


### PR DESCRIPTION
## Summary and Scope

CASMCMS-9452: Cleanup of leftover Cluster/RoleBindings under CMS

## Testing
Deployed the service on mug

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

