### PR TITLE
CASMCMS-9459: Updated `aee` version to 1.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Dependencies
+- CASMCMS-9459: Updated `aee` version to 1.19.0. It has python module updates.
+
 ## [1.31.0] - 06/05/2025
 ### Fixed
 - CASMCMS-9452: Cleanup of leftover Cluster/RoleBindings under CMS

--- a/update_external_versions.conf
+++ b/update_external_versions.conf
@@ -80,4 +80,4 @@
 
 image: cray-aee
     major: 1
-    minor: 18
+    minor: 19


### PR DESCRIPTION
## Summary and Scope
CASMCMS-9459: Updated `aee` version to 1.19.0. It has python module updates.

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

