### PR TITLE
CASMCMS-9466: Reverting back python module updates made in tag `aee``1.19.0` to resolve ansible-core dependency issues with target.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Dependencies
+- CASMCMS-9466: Reverting back python module updates made in tag `aee``1.19.0` to resolve ansible-core dependency issues with target.
+
 ## [1.32.0] - 06/26/2025
 ### Dependencies
 - CASMCMS-9459: Updated `aee` version to 1.19.0. It has python module updates.

--- a/update_external_versions.conf
+++ b/update_external_versions.conf
@@ -80,4 +80,4 @@
 
 image: cray-aee
     major: 1
-    minor: 19
+    minor: 20


### PR DESCRIPTION
CASMCMS-9466: Reverting back python module updates made in tag `aee``1.19.0` to resolve ansible-core dependency issues with target.

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

