### PR TITLE
CASMCMS-9474: Mount CA certs into ansible container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- CASMCMS-9474: Mount CA certs into ansible container
+
 ### Dependencies
 - Update `kubernetes` and `requests-retry-session` versions; constrain packages that previously were not constrained
 

--- a/src/cray/cfs/operator/events/session_events.py
+++ b/src/cray/cfs/operator/events/session_events.py
@@ -51,6 +51,7 @@ DEFAULT_ANSIBLE_CONFIG = 'cfs-default-ansible-cfg'
 DEFAULT_ANSIBLE_VERBOSITY = 0
 SHARED_DIRECTORY = '/inventory'
 VCS_USER_CREDENTIALS_DIR = '/etc/cray/vcs'
+CAINFO_PATH = '/etc/cray/ca/certificate_authority.crt'
 
 try:
     config.load_incluster_config()
@@ -214,7 +215,7 @@ class CFSSessionController:
         self._job_env = {}
         self._job_env['GIT_SSL_CAINFO'] = client.V1EnvVar(
             name='GIT_SSL_CAINFO',
-            value='/etc/cray/ca/certificate_authority.crt'
+            value=CAINFO_PATH
         )
         self._job_env['CFS_OPERATOR_LOG_LEVEL'] = client.V1EnvVar(
             name='CFS_OPERATOR_LOG_LEVEL',
@@ -238,7 +239,7 @@ class CFSSessionController:
         )
         self._job_env['SSL_CAINFO'] = client.V1EnvVar(
             name='SSL_CAINFO',
-            value='/etc/cray/ca/certificate_authority.crt'
+            value=CAINFO_PATH
         )
         self._job_env['VCS_USERNAME'] = client.V1EnvVar(
             name='VCS_USERNAME',
@@ -551,6 +552,7 @@ class CFSSessionController:
             ),
             env=[
                 self._job_env['SESSION_NAME'],
+                self._job_env['SSL_CAINFO'],
                 client.V1EnvVar(
                     name='ANSIBLE_ARGS',
                     value=" ".join(ansible_args)
@@ -571,6 +573,7 @@ class CFSSessionController:
             ],  # env
             volume_mounts=[
                 self._job_volume_mounts['CONFIG_VOL'],
+                self._job_volume_mounts['CA_PUBKEY'],
             ],  # volume_mounts
             args=[json.dumps(ansible_data)],
         )  # V1Container


### PR DESCRIPTION
[CASMTRIAGE-8351](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8351) was opened because a CFS session using the new SOPS enablement was failing with a certificate error when trying to access Vault. The identical API call worked from inside the ansible container, if I copied in the system CA certificates and used those. I consulted with Joel (who implemented the SOPS feature for CFS) and he agreed that providing the CA certs in the ansible container is the best way to address this.

This requires 2 PRs. This one modifies the CFS jobs that are created so that the ansible container has the CA certificate volume mounted into it, and the path of the certificate file specified in the `SSL_CAINFO` environment variable.

The other PR is to cray-aee, and imports the certificates into the system certs.

I have tested on wasp with both of these PRs in place, and it resolves the issue that was reported.